### PR TITLE
EVW-1218 Phase 2: Flight change link sent

### DIFF
--- a/acceptance_tests/features/step_definitions/general.js
+++ b/acceptance_tests/features/step_definitions/general.js
@@ -18,4 +18,8 @@ module.exports = function () {
         this.click(`input[value=Continue]`);
     });
 
+    this.Then(/^the page title should contain "([^"]*)"$/, function (string) {
+        this.assert.containsText('h1.heading-large', string);
+    });
+
 };

--- a/acceptance_tests/features/step_definitions/link-sent.js
+++ b/acceptance_tests/features/step_definitions/link-sent.js
@@ -1,0 +1,7 @@
+module.exports = function () {
+
+    this.Then(/^the page content should contain "([^"]*)"$/, function (string) {
+        this.assert.containsText('.grid-row p', string);
+    });
+
+};

--- a/acceptance_tests/features/update-journey-details.feature
+++ b/acceptance_tests/features/update-journey-details.feature
@@ -85,3 +85,9 @@ Scenario: Choosing Land
     method of road travel to Northern Ireland, eg bus or private car
     arrival point in Northern Ireland, for example, the town or bus station where your bus or car drops you off
     """
+
+Scenario: Requesting a flight change link
+
+  Given I am on the "Link sent" page
+  Then the page title should contain "Flight change link sent"
+  And the page content should contain "We have emailed you with a link for you to change your flight details."

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -16,5 +16,9 @@ module.exports = {
     template: 'email-us',
     controller: require('./controllers/email-us'),
     clearSession: false
+  },
+  '/link-sent': {
+    template: 'link-sent',
+    clearSession: false
   }
 };

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -57,11 +57,9 @@
         ]
     }
   },
-  "third-page": {
-    "header": "This page shows how to make a field mandatory depending on the answer to a previous question"
-  },
-  "fourth-page": {
-    "header": "This page demonstrates custom validation"
+  "link-sent": {
+    "header": "Flight change link sent",
+    "content": "We have emailed you with a link for you to change your flight details."
   },
   "confirm": {
     "table": {

--- a/apps/update-journey-details/views/link-sent.html
+++ b/apps/update-journey-details/views/link-sent.html
@@ -1,0 +1,22 @@
+{{<layout}}
+{{$step}}Step 3 of 3{{/step}}
+
+{{$journeyHeader}}
+{{#t}}journey.header{{/t}}
+{{/journeyHeader}}
+
+{{$validationSummary}}
+{{> partials-validation-summary}}
+{{/validationSummary}}
+
+{{$propositionHeader}}
+{{> partials-navigation}}
+{{/propositionHeader}}
+
+
+{{$content}}
+<h1 class="heading-large">{{#t}}pages.link-sent.header{{/t}}</h1>
+<p>{{#t}}pages.link-sent.content{{/t}}</p>
+{{/content}}
+
+{{/layout}}


### PR DESCRIPTION
Added a `/link-sent` page, which is displayed to customers after requesting a link to the self-service form so that they are able to change their flight details.

