### PR TITLE
EVW-1218 Phase 2: Flight change link sent

### DIFF
--- a/acceptance_tests/features/update-journey-details.feature
+++ b/acceptance_tests/features/update-journey-details.feature
@@ -89,5 +89,5 @@ Scenario: Choosing Land
 Scenario: Requesting a flight change link
 
   Given I am on the "Link sent" page
-  Then the page title should contain "Flight change link sent"
+  Then the page title should contain "Check your email"
   And the page content should contain "We have emailed you with a link for you to change your flight details."

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -58,7 +58,7 @@
     }
   },
   "link-sent": {
-    "header": "Flight change link sent",
+    "header": "Check your email",
     "content": "We have emailed you with a link for you to change your flight details."
   },
   "confirm": {


### PR DESCRIPTION
Changed the title of the `/link-sent` page.

## Before

<img width="606" alt="screen shot 2016-06-21 at 17 16 23" src="https://cloud.githubusercontent.com/assets/6839214/16237395/2f30a05c-37d4-11e6-8ea6-b5e90a6a9a52.png">

## After

<img width="576" alt="screen shot 2016-06-21 at 17 16 51" src="https://cloud.githubusercontent.com/assets/6839214/16237401/38c45d70-37d4-11e6-9724-b3bb84794e09.png">
