### PR TITLE
EVW-1361 Integration - Make a real call to the flight API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   - node_modules
 before_script:
 - npm run sass
-- NODE_ENV='ci' npm start&
+- NODE_ENV='ci' npm run ci&
 script:
 - npm run test:ci
 - npm run test:acceptance

--- a/acceptance_tests/features/step_definitions/general.js
+++ b/acceptance_tests/features/step_definitions/general.js
@@ -2,12 +2,17 @@
 
 const base = 'http://localhost:8080';
 const urlise = (text) => text.toLowerCase().replace(/[^\w ]+/g, '').replace(/ +/g, '-');
-const setUrl = (app, page) => `${base}/${urlise(app)}/${urlise(page)}`;
+const setUrl = (app, page) => `${base}/${urlise(app)}/${page ? urlise(page) : ''}`;
 
 module.exports = function () {
 
     this.When(/^I (?:start on|go to) the "([^"]*)" page of the "([^"]*)" app$/, function (page, app) {
         this.url(setUrl(app, page))
+        .waitForElementVisible('body', 1000);
+    });
+
+    this.When(/^I start the "([^"]*)" app$/, function (app) {
+        this.url(setUrl(app))
         .waitForElementVisible('body', 1000);
     });
 
@@ -58,6 +63,10 @@ module.exports = function () {
         strings.split(/\n/).forEach( function (string) {
             this.assert.containsText('ul.list', string);
         }, this);
+    });
+
+    this.Then(/^the "([^"]*)" should contain "([^"]*)"$/, function (field, value) {
+        this.assert.containsText(`.${urlise(field)}`, value);
     });
 
 };

--- a/acceptance_tests/features/update-journey-details.feature
+++ b/acceptance_tests/features/update-journey-details.feature
@@ -85,33 +85,38 @@ Feature: Updating Journey Details
 #     arrival point in Northern Ireland, for example, the town or bus station where your bus or car drops you off
 #     """
 
-Scenario: Entering new flight details happy path
+Scenario: Entering new flight details and correct flight found
 
-  Given I start on the "Flight number" page of the "Update journey details" app
+  Given I start the "Update journey details" app
   Then the page title should contain "Your new flight details"
-  And I enter "EK009" into "Flight number"
+  And I enter "KU101" into "Flight number"
   And I continue
   # Arrival date page
   Then I should be on the "Arrival date" page of the "Update journey details" app
   And the page title should contain "Your new flight details"
-  And I enter the date "08-08-2016" into "Arrival date"
+  And I enter the date "09-08-2016" into "Arrival date"
   And I continue
   # Is this your flight page
   Then I should be on the "Is this your flight" page of the "Update journey details" app
   And the page title should contain "Is this your flight to the UK?"
+  And the "Flight number" should contain "KU101"
+  And the "Departure airport" should contain "Dubai"
+  And the "Arrival airport" should contain "London - Gatwick"
+  And the "Arrival date" should contain "09/08/2016"
+  And the "Arrival time" should contain "19:45"
   And I click "Yes"
   And I continue
   # Departure date and time page
   Then I should be on the "Departure date and time" page of the "Update journey details" app
   And the page title should contain "Your journey to the UK"
-  And I enter the date "07-08-2016" into "Departure date"
+  And I enter the date "09-08-2016" into "Departure date"
   And I enter the time "12:23" into "Departure time"
   And I continue
   # Check your answers page
   Then the page title should contain "Check your answers"
   And the summary table should contain
     """
-    EK009
+    KU101
     """
   And I continue
   # Declaration page
@@ -124,19 +129,19 @@ Scenario: Entering new flight details happy path
     If I have completed this for someone else I have their full agreement.
     """
 
+Scenario: Entering new flight details and incorrect flight found
 
-Scenario: Entering new flight details unhappy path
-
-  Given I start on the "Flight number" page of the "Update journey details" app
+  Given I start the "Update journey details" app
   Then the page title should contain "Your new flight details"
-  And I enter "EK009" into "Flight number"
+  And I enter "KU101" into "Flight number"
   And I continue
   # Arrival date page
   Then I should be on the "Arrival date" page of the "Update journey details" app
   And the page title should contain "Your new flight details"
-  And I enter the date "08-08-2016" into "Arrival date"
+  And I enter the date "09-08-2016" into "Arrival date"
   And I continue
   # Is this your flight page
+  # Flight details on this page have been tested in the last test so we only need to test the flow here
   Then I should be on the "Is this your flight" page of the "Update journey details" app
   And the page title should contain "Is this your flight to the UK?"
   And I click "No"
@@ -146,3 +151,18 @@ Scenario: Entering new flight details unhappy path
   And the page title should contain "We can’t find your flight"
   And I retry
   Then I should be on the "Flight number" page of the "Update journey details" app
+
+Scenario: Entering new flight details and flight not found
+
+  Given I start the "Update journey details" app
+  Then the page title should contain "Your new flight details"
+  And I enter "NO0001" into "Flight number"
+  And I continue
+  # Arrival date page
+  Then I should be on the "Arrival date" page of the "Update journey details" app
+  And the page title should contain "Your new flight details"
+  And I enter the date "08-08-2016" into "Arrival date"
+  And I continue
+  # Flight not found page
+  Then I should be on the "Flight not found" page of the "Update journey details" app
+  And the page title should contain "We can’t find your flight"

--- a/apps/update-journey-details/controllers/arrival-date.js
+++ b/apps/update-journey-details/controllers/arrival-date.js
@@ -1,13 +1,36 @@
 'use strict';
 
 const util = require('util');
-const DateController = require('hof').controllers.date;
+const BaseController = require('hof').controllers.base;
+const flightLookup = require('../../../lib/flight-lookup');
 
-let ArrivalDateController = function ArrivalDateController() {
-  this.dateKey = 'arrival-date';
-  DateController.apply(this, arguments);
+const ArrivalDateController = function ArrivalDateController() {
+  BaseController.apply(this, arguments);
 };
 
-util.inherits(ArrivalDateController, DateController);
+util.inherits(ArrivalDateController, BaseController);
+
+ArrivalDateController.prototype.saveValues = function saveValues(req, res, callback) {
+    let lookupData = flightLookup.formatPost({
+        flightNumber: req.sessionModel.get('flight-number'),
+        arrivalDateDay: req.form.values['arrival-date-day'],
+        arrivalDateMonth: req.form.values['arrival-date-month'],
+        arrivalDateYear: req.form.values['arrival-date-year']
+    });
+
+    flightLookup.findFlight(lookupData.number, lookupData.date).then(function (foundData) {
+        let flight = foundData.body.flights[0];
+
+        // Flight found
+        if (typeof flight !== 'undefined') {
+            let mappedFlight = flightLookup.mapFlight(flight, req.sessionModel);
+            req.sessionModel.set('flightDetails', mappedFlight);
+        }
+
+        // Flight not found, page gets set in steps.js
+
+        callback();
+    });
+};
 
 module.exports = ArrivalDateController;

--- a/apps/update-journey-details/controllers/is-this-your-flight.js
+++ b/apps/update-journey-details/controllers/is-this-your-flight.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const util = require('util');
-const controllers = require('hof').controllers;
-const BaseController = controllers.base;
+const BaseController = require('hof').controllers.base;
 
 const IsThisYourFlightController = function IsThisYourFlightController() {
   BaseController.apply(this, arguments);
@@ -11,18 +10,9 @@ const IsThisYourFlightController = function IsThisYourFlightController() {
 util.inherits(IsThisYourFlightController, BaseController);
 
 IsThisYourFlightController.prototype.locals = function locals(req, res) {
-  return Object.assign(
-    {
-        flightDetails: {
-          flightNumber: 'EK0009',
-          departureAirport: 'Dubai',
-          arrivalAirport: 'London - Gatwick',
-          arrivalDate: '08/08/2016',
-          arrivalTime: '19:45'
-        }
-    },
-    BaseController.prototype.locals.call(this, req, res)
-  );
+  return Object.assign({
+    flightDetails: req.sessionModel.get('flightDetails')
+  }, BaseController.prototype.locals.call(this, req, res));
 };
 
 module.exports = IsThisYourFlightController;

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -31,12 +31,20 @@ module.exports = {
   },
   '/arrival-date': {
     template: 'arrival-date',
-    // Commented out until validation is sorted
-    // controller: require('./controllers/arrival-date'),
+    controller: require('./controllers/arrival-date'),
     fields: [
-      'arrival-date'
+      'arrival-date',
+      'arrival-date-day',
+      'arrival-date-month',
+      'arrival-date-year'
     ],
-    next: '/is-this-your-flight'
+    next: '/is-this-your-flight',
+    forks: [{
+      target: '/flight-not-found',
+      condition: function(req) {
+        return typeof req.sessionModel.get('flightDetails') === 'undefined';
+      }
+    }]
   },
   '/is-this-your-flight': {
     template: 'is-this-your-flight',

--- a/apps/update-journey-details/views/is-this-your-flight.html
+++ b/apps/update-journey-details/views/is-this-your-flight.html
@@ -21,23 +21,23 @@
 <table class="flight-details">
     <tr>
         <td>Flight Number</td>
-        <td class="flight-details-value">{{ flightDetails.flightNumber }}</td>
+        <td class="flight-details-value flight-number">{{ flightDetails.flightNumber }}</td>
     </tr>
     <tr>
         <td>Departure airport</td>
-        <td class="flight-details-value">{{ flightDetails.departureAirport }}</td>
+        <td class="flight-details-value departure-airport">{{ flightDetails.departureAirport }}</td>
     </tr>
     <tr>
         <td>Arrival airport</td>
-        <td class="flight-details-value">{{ flightDetails.arrivalAirport }}</td>
+        <td class="flight-details-value arrival-airport">{{ flightDetails.arrivalAirport }}</td>
     </tr>
     <tr>
         <td>Arrival date</td>
-        <td class="flight-details-value">{{ flightDetails.arrivalDate }}</td>
+        <td class="flight-details-value arrival-date">{{ flightDetails.arrivalDate }}</td>
     </tr>
     <tr>
         <td>Arrival time</td>
-        <td class="flight-details-value">{{ flightDetails.arrivalTime }}</td>
+        <td class="flight-details-value arrival-time">{{ flightDetails.arrivalTime }}</td>
     </tr>
 </table>
 

--- a/config/config.js
+++ b/config/config.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = {
+    flightService: {
+        url: process.env.FLIGHT_SERVICE_URL || 'http://localhost:9350',
+        timeout: 5000,
+        check: {
+            method: 'POST',
+            endpoint: 'check-flight-details'
+        }
+    }
+};

--- a/data/airports.json
+++ b/data/airports.json
@@ -1,0 +1,11783 @@
+[
+  {
+    "type": "plane",
+    "country": "Albania",
+    "country-code": "ALB",
+    "code": "TIA",
+    "name": "Tirana - Rinas"
+  },
+  {
+    "type": "plane",
+    "country": "Algeria",
+    "country-code": "DZA",
+    "code": "ALG",
+    "name": "Algiers"
+  },
+  {
+    "type": "plane",
+    "country": "Algeria",
+    "country-code": "DZA",
+    "code": "AAE",
+    "name": "Annaba"
+  },
+  {
+    "type": "plane",
+    "country": "Algeria",
+    "country-code": "DZA",
+    "code": "CZL",
+    "name": "Constantine"
+  },
+  {
+    "type": "plane",
+    "country": "Algeria",
+    "country-code": "DZA",
+    "code": "ORN",
+    "name": "Oran (Ouahran)"
+  },
+  {
+    "type": "plane",
+    "country": "American Samoa",
+    "country-code": "ASM",
+    "code": "PPG",
+    "name": "Pago Pago"
+  },
+  {
+    "type": "plane",
+    "country": "Andorra",
+    "country-code": "AND",
+    "code": "ALV",
+    "name": "Andorra La Vella H/P"
+  },
+  {
+    "type": "plane",
+    "country": "Angola",
+    "country-code": "AGO",
+    "code": "BUG",
+    "name": "Bengueka"
+  },
+  {
+    "type": "plane",
+    "country": "Angola",
+    "country-code": "AGO",
+    "code": "CAB",
+    "name": "Cabinda"
+  },
+  {
+    "type": "plane",
+    "country": "Angola",
+    "country-code": "AGO",
+    "code": "LAD",
+    "name": "Luanda - 4 de Fevereiro"
+  },
+  {
+    "type": "plane",
+    "country": "Anguilla",
+    "country-code": "AIA",
+    "code": "AXA",
+    "name": "Anguilla"
+  },
+  {
+    "type": "plane",
+    "country": "Antigua And Barbuda",
+    "country-code": "ATG",
+    "code": "ANU",
+    "name": "Antigua"
+  },
+  {
+    "type": "plane",
+    "country": "Argentina",
+    "country-code": "ARG",
+    "code": "BUE",
+    "name": "Buenos Aires"
+  },
+  {
+    "type": "plane",
+    "country": "Argentina",
+    "country-code": "ARG",
+    "code": "EZE",
+    "name": "Buenos Aires,Ezeiza Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Argentina",
+    "country-code": "ARG",
+    "code": "AEP",
+    "name": "Buenos Aires-JorgeNewbery"
+  },
+  {
+    "type": "plane",
+    "country": "Argentina",
+    "country-code": "ARG",
+    "code": "COR",
+    "name": "Cordoba"
+  },
+  {
+    "type": "plane",
+    "country": "Argentina",
+    "country-code": "ARG",
+    "code": "MDQ",
+    "name": "Mar del Plata"
+  },
+  {
+    "type": "plane",
+    "country": "Argentina",
+    "country-code": "ARG",
+    "code": "MDZ",
+    "name": "Mendoza"
+  },
+  {
+    "type": "plane",
+    "country": "Argentina",
+    "country-code": "ARG",
+    "code": "ROS",
+    "name": "Rosario"
+  },
+  {
+    "type": "plane",
+    "country": "Argentina",
+    "country-code": "ARG",
+    "code": "BRC",
+    "name": "San Claros de Bariloche"
+  },
+  {
+    "type": "plane",
+    "country": "Armenia",
+    "country-code": "ARM",
+    "code": "EVN",
+    "name": "Eriwan (Yerevan, Jerevan)"
+  },
+  {
+    "type": "plane",
+    "country": "Aruba",
+    "country-code": "ABW",
+    "code": "AUA",
+    "name": "Aruba"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "ADL",
+    "name": "Adelaide"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "ALH",
+    "name": "Albany"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "ABX",
+    "name": "Albury"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "ASP",
+    "name": "Alice Springs"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "BNK",
+    "name": "Ballina"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "ABM",
+    "name": "Bamaga"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "BLT",
+    "name": "Blackwater"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "ZBO",
+    "name": "Bowen"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "BMP",
+    "name": "Brampton Island"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "BNE",
+    "name": "Brisbane"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "BHQ",
+    "name": "Broken Hill"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "BME",
+    "name": "Broome"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "BDB",
+    "name": "Bundaberg"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "BWT",
+    "name": "Burnie (Wynyard)"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "CNS",
+    "name": "Cairns"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "CBR",
+    "name": "Canberra"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "CVQ",
+    "name": "Carnarvon"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "CSI",
+    "name": "Casino"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "CED",
+    "name": "Ceduna"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "CES",
+    "name": "Cessnock"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "CXT",
+    "name": "Charters Towers"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "CMQ",
+    "name": "Clermont"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "CFS",
+    "name": "Coffs Harbour"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "KCE",
+    "name": "Collinsville"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "CPD",
+    "name": "Coober Pedy"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "CTN",
+    "name": "Cooktown"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "OOM",
+    "name": "Cooma"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "DBY",
+    "name": "Dalby"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "DRW",
+    "name": "Darwin"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "DDI",
+    "name": "Daydream Island"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "DRB",
+    "name": "Derby"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "DPO",
+    "name": "Devonport"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "DBO",
+    "name": "Dubbo"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "DKI",
+    "name": "Dunk Iceland"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "DYA",
+    "name": "Dysart"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "EDR",
+    "name": "Emerald"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "EMD",
+    "name": "Emerald"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "EPR",
+    "name": "Esperance"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "GEX",
+    "name": "Geelong"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "GET",
+    "name": "Geraldton"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "GLT",
+    "name": "Gladstone"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "OOL",
+    "name": "Gold Coast"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "GOO",
+    "name": "Goondiwindi"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "GOV",
+    "name": "Gove (Nhulunbuy)"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "GKL",
+    "name": "Great Keppel Island"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "GFF",
+    "name": "Griffith"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "GTE",
+    "name": "Groote Eyeland"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "GTI",
+    "name": "Groote Eylandt"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "GYP",
+    "name": "Gympie"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "HLT",
+    "name": "Hamilton"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "HTI",
+    "name": "Hamilton Island"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "HIS",
+    "name": "Hayman Island"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "HVB",
+    "name": "Hervey Bay"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "HNK",
+    "name": "Hinchinbrook Island"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "HBA",
+    "name": "Hobart"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "HMH",
+    "name": "Home Hill"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "HIR",
+    "name": "Honiara"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "IGH",
+    "name": "Ingham"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "IFL",
+    "name": "Innisfail"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "KGI",
+    "name": "Kalgoorlie"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "KTA",
+    "name": "Karratha"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "KRB",
+    "name": "Karumba"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "KTR",
+    "name": "Katherine"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "KNS",
+    "name": "King Island"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "KGC",
+    "name": "Kingscote"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "KWM",
+    "name": "Kowanyama"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "KNX",
+    "name": "Kununurra"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "LST",
+    "name": "Launceston"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "LVO",
+    "name": "Laverton"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "LEA",
+    "name": "Learmouth (Exmouth)"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "LER",
+    "name": "Leinster"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "LNO",
+    "name": "Leonora"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "LDC",
+    "name": "Lindeman Island"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "LSY",
+    "name": "Lismore"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "LZR",
+    "name": "Lizard Island"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "IRG",
+    "name": "Lockhart River"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "LRE",
+    "name": "Longreach"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "MKY",
+    "name": "Mackay"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "MTL",
+    "name": "Maitland"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "MBH",
+    "name": "Maryborough"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "MKR",
+    "name": "Meekatharra"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "MEL",
+    "name": "Melbourne - Tullamarine"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "MIM",
+    "name": "Merimbula"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "MMM",
+    "name": "Middlemount"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "MQL",
+    "name": "Mildura"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "MOV",
+    "name": "Moranbah"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "MRZ",
+    "name": "Moree"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "MGB",
+    "name": "Mount Gambier"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "MMG",
+    "name": "Mount Magnet"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "ISA",
+    "name": "Mt. Isa"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "NAA",
+    "name": "Narrabri"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "NRA",
+    "name": "Narrandera"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "BEO",
+    "name": "Newcastle - Belmont"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "NTL",
+    "name": "Newcastle - Williamtown"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "ZNE",
+    "name": "Newman"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "NSA",
+    "name": "Noosa"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "NLK",
+    "name": "Norfolk Island"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "OLP",
+    "name": "Olympic Dam"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "OAG",
+    "name": "Orange"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "ORS",
+    "name": "Orpheus Island"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "PBO",
+    "name": "Paraburdoo"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "PER",
+    "name": "Perth Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "PUG",
+    "name": "Port Augusta"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "PHE",
+    "name": "Port Hedland"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "PLO",
+    "name": "Port Lincoln"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "PQQ",
+    "name": "Port Macquarie"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "PTJ",
+    "name": "Portland"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "PPP",
+    "name": "Prosperpine"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "UEE",
+    "name": "Queenstown"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "ROK",
+    "name": "Rockhampton"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "NSO",
+    "name": "Scone"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "JHQ",
+    "name": "Shute Harbour"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "SIX",
+    "name": "Singleton"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "SOI",
+    "name": "South Molle Island"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "KBY",
+    "name": "Streaky Bay"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "MCY",
+    "name": "Sunshine Coast"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "SYD",
+    "name": "Sydney - Kingsford Smith"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "TMW",
+    "name": "Tamworth"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "TRO",
+    "name": "Taree"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "TEM",
+    "name": "Temora"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "TCA",
+    "name": "Tennant Creek"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "TIS",
+    "name": "Thursday Island"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "TPR",
+    "name": "Tom Price"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "TWB",
+    "name": "Toowoomba"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "TSV",
+    "name": "Townsville"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "WGA",
+    "name": "Wagga"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "WMB",
+    "name": "Warrnambool"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "WEI",
+    "name": "Weipa"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "HAP",
+    "name": "Whitsunday Resort"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "WYA",
+    "name": "Whyalla"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "WHM",
+    "name": "Wickham"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "WUN",
+    "name": "Wiluna"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "WOL",
+    "name": "Wollongong"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "UMR",
+    "name": "Woomera"
+  },
+  {
+    "type": "plane",
+    "country": "Australia",
+    "country-code": "AUS",
+    "code": "WYN",
+    "name": "Wyndham"
+  },
+  {
+    "type": "plane",
+    "country": "Austria",
+    "country-code": "AUT",
+    "code": "GRZ",
+    "name": "Graz"
+  },
+  {
+    "type": "plane",
+    "country": "Austria",
+    "country-code": "AUT",
+    "code": "INN",
+    "name": "Innsbruck - Kranebitten"
+  },
+  {
+    "type": "plane",
+    "country": "Austria",
+    "country-code": "AUT",
+    "code": "KLU",
+    "name": "Klagenfurt"
+  },
+  {
+    "type": "plane",
+    "country": "Austria",
+    "country-code": "AUT",
+    "code": "LNZ",
+    "name": "Linz - Hoersching"
+  },
+  {
+    "type": "plane",
+    "country": "Austria",
+    "country-code": "AUT",
+    "code": "SZG",
+    "name": "Salzburg - W.A. Mozart"
+  },
+  {
+    "type": "plane",
+    "country": "Austria",
+    "country-code": "AUT",
+    "code": "VIE",
+    "name": "Wien (Vienna) Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Azerbaijan",
+    "country-code": "AZE",
+    "code": "BAK",
+    "name": "Baku"
+  },
+  {
+    "type": "plane",
+    "country": "Bahamas",
+    "country-code": "BHS",
+    "code": "CCZ",
+    "name": "Chub Cay"
+  },
+  {
+    "type": "plane",
+    "country": "Bahamas",
+    "country-code": "BHS",
+    "code": "FPO",
+    "name": "Freeport"
+  },
+  {
+    "type": "plane",
+    "country": "Bahamas",
+    "country-code": "BHS",
+    "code": "GHB",
+    "name": "Govenors Harbour"
+  },
+  {
+    "type": "plane",
+    "country": "Bahamas",
+    "country-code": "BHS",
+    "code": "GBI",
+    "name": "Grand Bahama"
+  },
+  {
+    "type": "plane",
+    "country": "Bahamas",
+    "country-code": "BHS",
+    "code": "MHH",
+    "name": "Marsh Harbour"
+  },
+  {
+    "type": "plane",
+    "country": "Bahamas",
+    "country-code": "BHS",
+    "code": "NAS",
+    "name": "Nassau"
+  },
+  {
+    "type": "plane",
+    "country": "Bahamas",
+    "country-code": "BHS",
+    "code": "ELH",
+    "name": "North Eleuthera"
+  },
+  {
+    "type": "plane",
+    "country": "Bahamas",
+    "country-code": "BHS",
+    "code": "RSD",
+    "name": "Rock Sound"
+  },
+  {
+    "type": "plane",
+    "country": "Bahamas",
+    "country-code": "BHS",
+    "code": "ZSA",
+    "name": "San Salvador"
+  },
+  {
+    "type": "plane",
+    "country": "Bahamas",
+    "country-code": "BHS",
+    "code": "TCB",
+    "name": "Treasure Cay"
+  },
+  {
+    "type": "plane",
+    "country": "Bahrain",
+    "country-code": "BHR",
+    "code": "BAH",
+    "name": "Bahrain"
+  },
+  {
+    "type": "plane",
+    "country": "Bangladesh",
+    "country-code": "BGD",
+    "code": "BZL",
+    "name": "Barisal"
+  },
+  {
+    "type": "plane",
+    "country": "Bangladesh",
+    "country-code": "BGD",
+    "code": "CGP",
+    "name": "Chittagong"
+  },
+  {
+    "type": "plane",
+    "country": "Bangladesh",
+    "country-code": "BGD",
+    "code": "DAC",
+    "name": "Dhaka"
+  },
+  {
+    "type": "plane",
+    "country": "Barbados",
+    "country-code": "BRB",
+    "code": "BGI",
+    "name": "Bridgetown"
+  },
+  {
+    "type": "plane",
+    "country": "Belarus",
+    "country-code": "BLR",
+    "code": "MSQ",
+    "name": "Minsk, International"
+  },
+  {
+    "type": "plane",
+    "country": "Belgium",
+    "country-code": "BEL",
+    "code": "ANR",
+    "name": "Antwerp"
+  },
+  {
+    "type": "plane",
+    "country": "Belgium",
+    "country-code": "BEL",
+    "code": "BRU",
+    "name": "Brussels"
+  },
+  {
+    "type": "plane",
+    "country": "Belgium",
+    "country-code": "BEL",
+    "code": "LGG",
+    "name": "Liege"
+  },
+  {
+    "type": "plane",
+    "country": "Belize",
+    "country-code": "BLZ",
+    "code": "BZE",
+    "name": "Belize City"
+  },
+  {
+    "type": "plane",
+    "country": "Benin",
+    "country-code": "BEN",
+    "code": "COO",
+    "name": "Cotonou"
+  },
+  {
+    "type": "plane",
+    "country": "Bermuda",
+    "country-code": "BMU",
+    "code": "BDA",
+    "name": "Bermuda"
+  },
+  {
+    "type": "plane",
+    "country": "Bolivia",
+    "country-code": "BOL",
+    "code": "CBB",
+    "name": "Cochabamba"
+  },
+  {
+    "type": "plane",
+    "country": "Bolivia",
+    "country-code": "BOL",
+    "code": "LPB",
+    "name": "La Paz - El Alto"
+  },
+  {
+    "type": "plane",
+    "country": "Bolivia",
+    "country-code": "BOL",
+    "code": "SRZ",
+    "name": "Santa Cruz de la Sierra"
+  },
+  {
+    "type": "plane",
+    "country": "Bosnia And Herzegovina",
+    "country-code": "BIH",
+    "code": "OMO",
+    "name": "Mostar"
+  },
+  {
+    "type": "plane",
+    "country": "Bosnia And Herzegovina",
+    "country-code": "BIH",
+    "code": "SJJ",
+    "name": "Sarajevo"
+  },
+  {
+    "type": "plane",
+    "country": "Botswana",
+    "country-code": "BWA",
+    "code": "GBE",
+    "name": "Gaborone"
+  },
+  {
+    "type": "plane",
+    "country": "Botswana",
+    "country-code": "BWA",
+    "code": "MUB",
+    "name": "Maun"
+  },
+  {
+    "type": "plane",
+    "country": "Botswana",
+    "country-code": "BWA",
+    "code": "PKW",
+    "name": "Selibi Phikwe"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "AJU",
+    "name": "Aracaju"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "BEL",
+    "name": "Belem"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "CNF",
+    "name": "Belo Horizonte"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "BVB",
+    "name": "Boa Vista"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "BSB",
+    "name": "Brasilia"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "CGR",
+    "name": "Campo Grande"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "CGB",
+    "name": "Cuiaba"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "CWB",
+    "name": "Curitiba"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "FLN",
+    "name": "Florianopolis"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "FOR",
+    "name": "Fortaleza"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "GYN",
+    "name": "Goiania"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "JCB",
+    "name": "Joacaba"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "JPA",
+    "name": "Joao Pessoa-Castro Pinto"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "MCP",
+    "name": "Macapa"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "MCZ",
+    "name": "Maceio"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "MAO",
+    "name": "Manaus"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "QGF",
+    "name": "Montenegro"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "NAT",
+    "name": "Natal"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "POA",
+    "name": "Porto Alegre"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "PVH",
+    "name": "Porto Velho"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "REC",
+    "name": "Recife"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "RBR",
+    "name": "Rio Branco"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "RIO",
+    "name": "Rio de Janeiro"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "GIG",
+    "name": "Rio de Janeiro - Galeao"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "SDU",
+    "name": "Rio de Janeiro-St. Dumont"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "SSA",
+    "name": "Salvador"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "SLZ",
+    "name": "Sao Luis"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "SAO",
+    "name": "Sao Paulo"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "CGH",
+    "name": "Sao Paulo - Congonhas"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "GRU",
+    "name": "Sao Paulo - Guarulhos"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "VCP",
+    "name": "Sao Paulo - Viracopos"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "THE",
+    "name": "Teresina"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "UDI",
+    "name": "Uberlandia, MG"
+  },
+  {
+    "type": "plane",
+    "country": "Brazil",
+    "country-code": "BRA",
+    "code": "VIX",
+    "name": "Vitoria"
+  },
+  {
+    "type": "plane",
+    "country": "Brunei",
+    "country-code": "BRN",
+    "code": "BWN",
+    "name": "Bandar Seri Begawan"
+  },
+  {
+    "type": "plane",
+    "country": "Brunei",
+    "country-code": "BRN",
+    "code": "KUB",
+    "name": "Kuala Belait"
+  },
+  {
+    "type": "plane",
+    "country": "Bulgaria",
+    "country-code": "BGR",
+    "code": "BOJ",
+    "name": "Bourgas/Burgas"
+  },
+  {
+    "type": "plane",
+    "country": "Bulgaria",
+    "country-code": "BGR",
+    "code": "GOZ",
+    "name": "Gorna"
+  },
+  {
+    "type": "plane",
+    "country": "Bulgaria",
+    "country-code": "BGR",
+    "code": "ROU",
+    "name": "Ruse"
+  },
+  {
+    "type": "plane",
+    "country": "Bulgaria",
+    "country-code": "BGR",
+    "code": "SLS",
+    "name": "Silistra"
+  },
+  {
+    "type": "plane",
+    "country": "Bulgaria",
+    "country-code": "BGR",
+    "code": "SOF",
+    "name": "Sofia - Vrazhdebna"
+  },
+  {
+    "type": "plane",
+    "country": "Bulgaria",
+    "country-code": "BGR",
+    "code": "TGV",
+    "name": "Targovishte"
+  },
+  {
+    "type": "plane",
+    "country": "Bulgaria",
+    "country-code": "BGR",
+    "code": "VAR",
+    "name": "Varna"
+  },
+  {
+    "type": "plane",
+    "country": "Bulgaria",
+    "country-code": "BGR",
+    "code": "VID",
+    "name": "Vidin"
+  },
+  {
+    "type": "plane",
+    "country": "Burkina",
+    "country-code": "BFA",
+    "code": "BOY",
+    "name": "Bobo/Dioulasso"
+  },
+  {
+    "type": "plane",
+    "country": "Burkina",
+    "country-code": "BFA",
+    "code": "OUA",
+    "name": "Ouagadougou"
+  },
+  {
+    "type": "plane",
+    "country": "Burma (Myanmar)",
+    "country-code": "MMR",
+    "code": "RGN",
+    "name": "Rangoon/Yangon-Mingaladon"
+  },
+  {
+    "type": "plane",
+    "country": "Burundi",
+    "country-code": "BDI",
+    "code": "BJM",
+    "name": "Bujumbura"
+  },
+  {
+    "type": "plane",
+    "country": "Cambodia",
+    "country-code": "KHM",
+    "code": "PNH",
+    "name": "Phnom Penh - Pochentong"
+  },
+  {
+    "type": "plane",
+    "country": "Cameroon",
+    "country-code": "CMR",
+    "code": "DLA",
+    "name": "Douala"
+  },
+  {
+    "type": "plane",
+    "country": "Cameroon",
+    "country-code": "CMR",
+    "code": "GOU",
+    "name": "Garoua"
+  },
+  {
+    "type": "plane",
+    "country": "Cameroon",
+    "country-code": "CMR",
+    "code": "MVR",
+    "name": "Maroua"
+  },
+  {
+    "type": "plane",
+    "country": "Cameroon",
+    "country-code": "CMR",
+    "code": "NGE",
+    "name": "N'Gaoundere"
+  },
+  {
+    "type": "plane",
+    "country": "Cameroon",
+    "country-code": "CMR",
+    "code": "YAO",
+    "name": "Yaounde"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YAT",
+    "name": "Attawapiskat, NT"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YVB",
+    "name": "Bonaventure, PQ"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YYC",
+    "name": "Calgary/Banff"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YCB",
+    "name": "Cambridge Bay"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YYQ",
+    "name": "Churchill"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "CFG",
+    "name": "Cienfuegos"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YDF",
+    "name": "Deer Lake/Corner Brook"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YEA",
+    "name": "Edmonton"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YEG",
+    "name": "Edmonton, International"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YXD",
+    "name": "Edmonton, Municipal"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YFO",
+    "name": "Flin Flon"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YFA",
+    "name": "Fort Albert"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YMM",
+    "name": "Fort McMurray"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YSM",
+    "name": "Fort Smith"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YXJ",
+    "name": "Fort St. John"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YFC",
+    "name": "Fredericton"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YQX",
+    "name": "Gander"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YGX",
+    "name": "Gillam"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YYR",
+    "name": "Goose Bay"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YHZ",
+    "name": "Halifax Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YUX",
+    "name": "Hall Beach"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YHM",
+    "name": "Hamilton"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YHR",
+    "name": "Harrington Harbour, PQ"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YEV",
+    "name": "Inuvik"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YFB",
+    "name": "Iqaluit (Frobisher Bay)"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "ZKE",
+    "name": "Kaschechawan, PQ"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YLW",
+    "name": "Kelowna, BC"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YVP",
+    "name": "Kuujjuaq (FortChimo)"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YGW",
+    "name": "Kuujjuarapik"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YGL",
+    "name": "La Grande"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "XLB",
+    "name": "Lac Brochet, MB"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YLR",
+    "name": "Leaf Rapids"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YXU",
+    "name": "London"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YMQ",
+    "name": "Montreal"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YUL",
+    "name": "Montreal - Dorval"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YMX",
+    "name": "Montreal - Mirabel"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YSR",
+    "name": "Nanisivik"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YVQ",
+    "name": "Norman Wells"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YOW",
+    "name": "Ottawa - Hull"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YPN",
+    "name": "Port Menier, PQ"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YXS",
+    "name": "Prince George"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YPR",
+    "name": "Prince Rupert/Digby Is'nd"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "XPK",
+    "name": "Pukatawagan"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YQB",
+    "name": "Quebec - Quebec Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YOP",
+    "name": "Rainbow Lake, AB"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YQR",
+    "name": "Regina"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YRB",
+    "name": "Resolute Bay"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YSJ",
+    "name": "Saint John"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YZP",
+    "name": "Sandspit"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YXE",
+    "name": "Saskatoon"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "ZTM",
+    "name": "Shamattawa, MB"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YYD",
+    "name": "Smithers"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "XSI",
+    "name": "South Indian Lake, MB"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YIF",
+    "name": "St. Augustin, PQ"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YYT",
+    "name": "St. John's"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "FSP",
+    "name": "St. Pierre, NF"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YXT",
+    "name": "Terrace"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YQD",
+    "name": "The Pas"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YTH",
+    "name": "Thompson"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YQT",
+    "name": "Thunder Bay"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YTO",
+    "name": "Toronto"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YTZ",
+    "name": "Toronto Island"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YYZ",
+    "name": "Toronto-Lester B.Pearson"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YVO",
+    "name": "Val d'Or"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YVR",
+    "name": "Vancouver-Vancouver Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YYJ",
+    "name": "Victoria"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YWK",
+    "name": "Wabush"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YXN",
+    "name": "Whale Cove, NT"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YXY",
+    "name": "Whitehorse"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YQG",
+    "name": "Windsor Ontario"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YWG",
+    "name": "Winnipeg Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Canada",
+    "country-code": "CAN",
+    "code": "YZF",
+    "name": "Yellowknife"
+  },
+  {
+    "type": "plane",
+    "country": "Cape Verde",
+    "country-code": "CPV",
+    "code": "RAI",
+    "name": "Praia"
+  },
+  {
+    "type": "plane",
+    "country": "Cape Verde",
+    "country-code": "CPV",
+    "code": "SID",
+    "name": "Sal"
+  },
+  {
+    "type": "plane",
+    "country": "Cayman Islands",
+    "country-code": "CYM",
+    "code": "GCM",
+    "name": "Grand Cayman"
+  },
+  {
+    "type": "plane",
+    "country": "Central African Republic",
+    "country-code": "CAF",
+    "code": "BBY",
+    "name": "Bambari"
+  },
+  {
+    "type": "plane",
+    "country": "Central African Republic",
+    "country-code": "CAF",
+    "code": "BGU",
+    "name": "Bangassou"
+  },
+  {
+    "type": "plane",
+    "country": "Central African Republic",
+    "country-code": "CAF",
+    "code": "BGF",
+    "name": "Bangui"
+  },
+  {
+    "type": "plane",
+    "country": "Central African Republic",
+    "country-code": "CAF",
+    "code": "BBT",
+    "name": "Berberati"
+  },
+  {
+    "type": "plane",
+    "country": "Central African Republic",
+    "country-code": "CAF",
+    "code": "IRO",
+    "name": "Biraro"
+  },
+  {
+    "type": "plane",
+    "country": "Central African Republic",
+    "country-code": "CAF",
+    "code": "BIV",
+    "name": "Bria"
+  },
+  {
+    "type": "plane",
+    "country": "Central African Republic",
+    "country-code": "CAF",
+    "code": "CRF",
+    "name": "Carnot"
+  },
+  {
+    "type": "plane",
+    "country": "Central African Republic",
+    "country-code": "CAF",
+    "code": "ODA",
+    "name": "Ouadda"
+  },
+  {
+    "type": "plane",
+    "country": "Chad",
+    "country-code": "TCD",
+    "code": "AEH",
+    "name": "Abeche"
+  },
+  {
+    "type": "plane",
+    "country": "Chad",
+    "country-code": "TCD",
+    "code": "MQQ",
+    "name": "Moundou"
+  },
+  {
+    "type": "plane",
+    "country": "Chad",
+    "country-code": "TCD",
+    "code": "NDJ",
+    "name": "N'Djamena"
+  },
+  {
+    "type": "plane",
+    "country": "Chile",
+    "country-code": "CHL",
+    "code": "IPC",
+    "name": "Easter Island"
+  },
+  {
+    "type": "plane",
+    "country": "Chile",
+    "country-code": "CHL",
+    "code": "PUQ",
+    "name": "Punta Arenas"
+  },
+  {
+    "type": "plane",
+    "country": "Chile",
+    "country-code": "CHL",
+    "code": "SCL",
+    "name": "Santiago de Chile-Benitez"
+  },
+  {
+    "type": "plane",
+    "country": "Chile",
+    "country-code": "CHL",
+    "code": "VAP",
+    "name": "Valparaiso"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "PEK",
+    "name": "Beijing"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "NAY",
+    "name": "Beijing - Nanyuan Airport"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "CGQ",
+    "name": "Changchun"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "CTU",
+    "name": "Chengdu"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "CKG",
+    "name": "Chongqing"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "DLC",
+    "name": "Dalian"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "DOH 2",
+    "name": "Dongguan"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "CAN",
+    "name": "Guangzhou (Kanton)-Baiyun"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "HGH",
+    "name": "Hangchow (Hangzhou)"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "HRB",
+    "name": "Harbin (Haerbin)"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "TNA",
+    "name": "Jinan"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "NNG",
+    "name": "Nanning"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "TAO",
+    "name": "Qingdao"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "SHA",
+    "name": "Shanghai - Hongqiao"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "PVG",
+    "name": "Shanghai - Pu Dong"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "SHE",
+    "name": "Shenyang"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "SZX",
+    "name": "Shenzhen"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "TYN",
+    "name": "Taiyuan"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "TSN",
+    "name": "Tianjin"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "URC",
+    "name": "Urumqi"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "WUH",
+    "name": "Wuhan"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "XMN",
+    "name": "Xiamen"
+  },
+  {
+    "type": "plane",
+    "country": "China",
+    "country-code": "CHN",
+    "code": "XIY",
+    "name": "Xi'an - Xianyang"
+  },
+  {
+    "type": "plane",
+    "country": "Colombia",
+    "country-code": "COL",
+    "code": "AXS",
+    "name": "Armenia"
+  },
+  {
+    "type": "plane",
+    "country": "Colombia",
+    "country-code": "COL",
+    "code": "BAQ",
+    "name": "Barranquilla"
+  },
+  {
+    "type": "plane",
+    "country": "Colombia",
+    "country-code": "COL",
+    "code": "BOG",
+    "name": "Bogota"
+  },
+  {
+    "type": "plane",
+    "country": "Colombia",
+    "country-code": "COL",
+    "code": "BGA",
+    "name": "Bucaramanga"
+  },
+  {
+    "type": "plane",
+    "country": "Colombia",
+    "country-code": "COL",
+    "code": "CLO",
+    "name": "Cali"
+  },
+  {
+    "type": "plane",
+    "country": "Colombia",
+    "country-code": "COL",
+    "code": "CTG",
+    "name": "Catagena"
+  },
+  {
+    "type": "plane",
+    "country": "Colombia",
+    "country-code": "COL",
+    "code": "MDE",
+    "name": "Medellin"
+  },
+  {
+    "type": "plane",
+    "country": "Colombia",
+    "country-code": "COL",
+    "code": "PEI",
+    "name": "Pereira"
+  },
+  {
+    "type": "plane",
+    "country": "Colombia",
+    "country-code": "COL",
+    "code": "ADZ",
+    "name": "San Andres"
+  },
+  {
+    "type": "plane",
+    "country": "Comoros",
+    "country-code": "COM",
+    "code": "AJN",
+    "name": "Anjouan"
+  },
+  {
+    "type": "plane",
+    "country": "Comoros",
+    "country-code": "COM",
+    "code": "YVA",
+    "name": "Moroni - Iconi"
+  },
+  {
+    "type": "plane",
+    "country": "Comoros",
+    "country-code": "COM",
+    "code": "HAH",
+    "name": "Moroni-PrinceSaid Ibrahim"
+  },
+  {
+    "type": "plane",
+    "country": "Congo",
+    "country-code": "COG",
+    "code": "BZV",
+    "name": "Brazzaville"
+  },
+  {
+    "type": "plane",
+    "country": "Congo",
+    "country-code": "COG",
+    "code": "PNR",
+    "name": "Pointe Noire"
+  },
+  {
+    "type": "plane",
+    "country": "Costa Rica",
+    "country-code": "CRI",
+    "code": "SJO",
+    "name": "San Jose"
+  },
+  {
+    "type": "plane",
+    "country": "Croatia",
+    "country-code": "HRV",
+    "code": "LSZ",
+    "name": "(Mali) Losinj Airport"
+  },
+  {
+    "type": "plane",
+    "country": "Croatia",
+    "country-code": "HRV",
+    "code": "DBV",
+    "name": "Dubrovnik"
+  },
+  {
+    "type": "plane",
+    "country": "Croatia",
+    "country-code": "HRV",
+    "code": "OSI",
+    "name": "Osijek"
+  },
+  {
+    "type": "plane",
+    "country": "Croatia",
+    "country-code": "HRV",
+    "code": "PUY",
+    "name": "Pula"
+  },
+  {
+    "type": "plane",
+    "country": "Croatia",
+    "country-code": "HRV",
+    "code": "RJK",
+    "name": "Rijeka"
+  },
+  {
+    "type": "plane",
+    "country": "Croatia",
+    "country-code": "HRV",
+    "code": "SPU",
+    "name": "Split"
+  },
+  {
+    "type": "plane",
+    "country": "Croatia",
+    "country-code": "HRV",
+    "code": "ZAD",
+    "name": "Zadar"
+  },
+  {
+    "type": "plane",
+    "country": "Croatia",
+    "country-code": "HRV",
+    "code": "ZAG",
+    "name": "Zagreb - Pleso"
+  },
+  {
+    "type": "plane",
+    "country": "Cuba",
+    "country-code": "CUB",
+    "code": "HAV",
+    "name": "Havana - Jose Marti Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Cuba",
+    "country-code": "CUB",
+    "code": "HOG",
+    "name": "Holguin"
+  },
+  {
+    "type": "plane",
+    "country": "Cuba",
+    "country-code": "CUB",
+    "code": "VRA",
+    "name": "Varadero"
+  },
+  {
+    "type": "plane",
+    "country": "Cyprus",
+    "country-code": "CYP",
+    "code": "LCA",
+    "name": "Larnaca"
+  },
+  {
+    "type": "plane",
+    "country": "Cyprus",
+    "country-code": "CYP",
+    "code": "QLI",
+    "name": "Limassol"
+  },
+  {
+    "type": "plane",
+    "country": "Cyprus",
+    "country-code": "CYP",
+    "code": "NIC",
+    "name": "Nicosia"
+  },
+  {
+    "type": "plane",
+    "country": "Cyprus",
+    "country-code": "CYP",
+    "code": "PFO",
+    "name": "Paphos"
+  },
+  {
+    "type": "plane",
+    "country": "Czech Republic",
+    "country-code": "CZE",
+    "code": "PRG",
+    "name": "Prague - Ruzyne"
+  },
+  {
+    "type": "plane",
+    "country": "Democratic Republic Of Congo",
+    "country-code": "COD",
+    "code": "FIH",
+    "name": "Kinshasa - N'Djili"
+  },
+  {
+    "type": "plane",
+    "country": "Democratic Republic Of Congo",
+    "country-code": "COD",
+    "code": "FKI",
+    "name": "Kisangani"
+  },
+  {
+    "type": "plane",
+    "country": "Democratic Republic Of Congo",
+    "country-code": "COD",
+    "code": "LIQ",
+    "name": "Lisala"
+  },
+  {
+    "type": "plane",
+    "country": "Democratic Republic Of Congo",
+    "country-code": "COD",
+    "code": "FBM",
+    "name": "Lumbumbashi"
+  },
+  {
+    "type": "plane",
+    "country": "Denmark",
+    "country-code": "DNK",
+    "code": "AAR",
+    "name": "Aarhus"
+  },
+  {
+    "type": "plane",
+    "country": "Denmark",
+    "country-code": "DNK",
+    "code": "AAL",
+    "name": "Alborg"
+  },
+  {
+    "type": "plane",
+    "country": "Denmark",
+    "country-code": "DNK",
+    "code": "BLL",
+    "name": "Billund"
+  },
+  {
+    "type": "plane",
+    "country": "Denmark",
+    "country-code": "DNK",
+    "code": "CPH",
+    "name": "Copenhagen"
+  },
+  {
+    "type": "plane",
+    "country": "Denmark",
+    "country-code": "DNK",
+    "code": "EBJ",
+    "name": "Esbjerg"
+  },
+  {
+    "type": "plane",
+    "country": "Denmark",
+    "country-code": "DNK",
+    "code": "FAE",
+    "name": "Faroer"
+  },
+  {
+    "type": "plane",
+    "country": "Denmark",
+    "country-code": "DNK",
+    "code": "KRP",
+    "name": "Karup"
+  },
+  {
+    "type": "plane",
+    "country": "Denmark",
+    "country-code": "DNK",
+    "code": "ODE",
+    "name": "Odense"
+  },
+  {
+    "type": "plane",
+    "country": "Denmark",
+    "country-code": "DNK",
+    "code": "RNN",
+    "name": "Roenne"
+  },
+  {
+    "type": "plane",
+    "country": "Denmark",
+    "country-code": "DNK",
+    "code": "SKS",
+    "name": "Skrydstrup"
+  },
+  {
+    "type": "plane",
+    "country": "Denmark",
+    "country-code": "DNK",
+    "code": "SGD",
+    "name": "Soenderborg"
+  },
+  {
+    "type": "plane",
+    "country": "Denmark",
+    "country-code": "DNK",
+    "code": "TED",
+    "name": "Thisted"
+  },
+  {
+    "type": "plane",
+    "country": "Djibouti",
+    "country-code": "DJI",
+    "code": "JIB",
+    "name": "Djibouti"
+  },
+  {
+    "type": "plane",
+    "country": "Dominican Republic",
+    "country-code": "DOM",
+    "code": "LRM",
+    "name": "Casa de Campo/La Romana"
+  },
+  {
+    "type": "plane",
+    "country": "Dominican Republic",
+    "country-code": "DOM",
+    "code": "POP",
+    "name": "Puerto Plata"
+  },
+  {
+    "type": "plane",
+    "country": "Dominican Republic",
+    "country-code": "DOM",
+    "code": "PUJ",
+    "name": "Punta Cana"
+  },
+  {
+    "type": "plane",
+    "country": "Dominican Republic",
+    "country-code": "DOM",
+    "code": "SDQ",
+    "name": "Santo Domingo"
+  },
+  {
+    "type": "plane",
+    "country": "Ecuador",
+    "country-code": "ECU",
+    "code": "GYE",
+    "name": "Guayaquil"
+  },
+  {
+    "type": "plane",
+    "country": "Ecuador",
+    "country-code": "ECU",
+    "code": "UIO",
+    "name": "Quito - Mariscal Sucr"
+  },
+  {
+    "type": "plane",
+    "country": "Ecuador",
+    "country-code": "ECU",
+    "code": "SNC",
+    "name": "Salinas"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "AUE",
+    "name": "Abu Rudeis"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "ABS",
+    "name": "Abu Simbel"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "AAC",
+    "name": "Al Arish"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "ALY",
+    "name": "Alexandria, El Nhouza"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "ATZ",
+    "name": "Assiut"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "ASW",
+    "name": "Aswan, Daraw Airport"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "CAI",
+    "name": "Cairo Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "EMY",
+    "name": "El Minya"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "HRG",
+    "name": "Hurghada Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "LXR",
+    "name": "Luxor"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "MUH",
+    "name": "Mersa Matruh"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "UVL",
+    "name": "New Valley - Kharga"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "PSD",
+    "name": "Port Said"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "SKV",
+    "name": "Santa Katarina-Mt Sinai"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "SSH",
+    "name": "Sharm El Sheikh"
+  },
+  {
+    "type": "plane",
+    "country": "Egypt",
+    "country-code": "EGY",
+    "code": "SEW",
+    "name": "Siwa"
+  },
+  {
+    "type": "plane",
+    "country": "El Salvador",
+    "country-code": "SLV",
+    "code": "SAL",
+    "name": "San Salvador"
+  },
+  {
+    "type": "plane",
+    "country": "Equatorial Guinea",
+    "country-code": "GNQ",
+    "code": "SSG",
+    "name": "Malabo"
+  },
+  {
+    "type": "plane",
+    "country": "Estonia",
+    "country-code": "EST",
+    "code": "QUF",
+    "name": "Tallinn - Pirita Harbour"
+  },
+  {
+    "type": "plane",
+    "country": "Estonia",
+    "country-code": "EST",
+    "code": "TLL",
+    "name": "Tallinn - Ulemiste"
+  },
+  {
+    "type": "plane",
+    "country": "Ethiopia",
+    "country-code": "ETH",
+    "code": "ADD",
+    "name": "Addis Ababa"
+  },
+  {
+    "type": "plane",
+    "country": "Fiji",
+    "country-code": "FJI",
+    "code": "NAN",
+    "name": "Nadi"
+  },
+  {
+    "type": "plane",
+    "country": "Fiji",
+    "country-code": "FJI",
+    "code": "SUV",
+    "name": "Suva/Nausori"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "ENF",
+    "name": "Enontekioe"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "HEL",
+    "name": "Helsinki - Vantaa"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "IVL",
+    "name": "Ivalo"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "JOE",
+    "name": "Joensuu"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "JYV",
+    "name": "Jyvaeskylae"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "KAJ",
+    "name": "Kajaani"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "KHJ",
+    "name": "Kauhajoki"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "KEM",
+    "name": "Kemi/Tornio"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "KOK",
+    "name": "Kokkola/Pietarsaari"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "KUO",
+    "name": "Kuopio"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "KAO",
+    "name": "Kuusamo"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "LPP",
+    "name": "Lappeenranta"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "MHQ",
+    "name": "Mariehamn (Maarianhamina)"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "MIK",
+    "name": "Mikkeli"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "OUL",
+    "name": "Oulu"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "POR",
+    "name": "Pori"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "RVN",
+    "name": "Rovaniemi"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "SVL",
+    "name": "Savonlinna"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "SJY",
+    "name": "Seinaejoki"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "SOT",
+    "name": "Sodankylae"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "TMP",
+    "name": "Tampere"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "TKU",
+    "name": "Turku"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "VAA",
+    "name": "Vaasa"
+  },
+  {
+    "type": "plane",
+    "country": "Finland",
+    "country-code": "FIN",
+    "code": "VRK",
+    "name": "Varkaus"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "AJA",
+    "name": "Ajaccio"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "LBI",
+    "name": "Albi"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "NCY",
+    "name": "Annecy"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "BIA",
+    "name": "Bastia"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "BIQ",
+    "name": "Biarritz"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "BOD",
+    "name": "Bordeaux"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "BES",
+    "name": "Brest"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "CLY",
+    "name": "Calvi"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "CMF",
+    "name": "Chambery"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "CFE",
+    "name": "Clermont Ferrand"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "DNR",
+    "name": "Dinard"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "FSC",
+    "name": "Figari"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "FRJ",
+    "name": "Frejus"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "GNB",
+    "name": "Grenoble"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "LRH",
+    "name": "La Rochelle"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "LAI",
+    "name": "Lannion"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "LIL",
+    "name": "Lille"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "LIG",
+    "name": "Limoges"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "LRT",
+    "name": "Lorient"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "LDE",
+    "name": "Lourdes/Tarbes"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "LYS",
+    "name": "Lyon"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "MRS",
+    "name": "Marseille"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "MZM",
+    "name": "Metz"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "MPL",
+    "name": "Montpellier - Frejorgues"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "MLH",
+    "name": "Mulhouse"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "ENC",
+    "name": "Nancy"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "NTE",
+    "name": "Nantes"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "NCE",
+    "name": "Nice - Cote D'Azur"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "FNI",
+    "name": "Nimes"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "PAR",
+    "name": "Paris"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "CDG",
+    "name": "Paris - Charles de Gaulle"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "LBG",
+    "name": "Paris - Le Bourget"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "ORY",
+    "name": "Paris - Orly"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "PUF",
+    "name": "Pau"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "PGF",
+    "name": "Perpignan"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "UIP",
+    "name": "Quimper"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "RNS",
+    "name": "Rennes"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "RNE",
+    "name": "Roanne"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "RDZ",
+    "name": "Rodez"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "SBK",
+    "name": "Saint Brieuc"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "EBU",
+    "name": "St. Etienne"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "SXB",
+    "name": "Strassburg"
+  },
+  {
+    "type": "plane",
+    "country": "France",
+    "country-code": "FRA",
+    "code": "TLS",
+    "name": "Toulouse - Blagnac"
+  },
+  {
+    "type": "plane",
+    "country": "French Guayana",
+    "country-code": "GUF",
+    "code": "CAY",
+    "name": "Cayenne"
+  },
+  {
+    "type": "plane",
+    "country": "French Polynesia",
+    "country-code": "PYF",
+    "code": "BOB",
+    "name": "Bora Bora"
+  },
+  {
+    "type": "plane",
+    "country": "French Polynesia",
+    "country-code": "PYF",
+    "code": "HUH",
+    "name": "Huahine"
+  },
+  {
+    "type": "plane",
+    "country": "French Polynesia",
+    "country-code": "PYF",
+    "code": "XMH",
+    "name": "Manihi"
+  },
+  {
+    "type": "plane",
+    "country": "French Polynesia",
+    "country-code": "PYF",
+    "code": "MAU",
+    "name": "Maupiti"
+  },
+  {
+    "type": "plane",
+    "country": "French Polynesia",
+    "country-code": "PYF",
+    "code": "MOZ",
+    "name": "Moorea"
+  },
+  {
+    "type": "plane",
+    "country": "French Polynesia",
+    "country-code": "PYF",
+    "code": "PPT",
+    "name": "Papeete - Faaa"
+  },
+  {
+    "type": "plane",
+    "country": "French Polynesia",
+    "country-code": "PYF",
+    "code": "RFP",
+    "name": "Raiatea"
+  },
+  {
+    "type": "plane",
+    "country": "French Polynesia",
+    "country-code": "PYF",
+    "code": "RGI",
+    "name": "Rangiroa"
+  },
+  {
+    "type": "plane",
+    "country": "Gabon",
+    "country-code": "GAB",
+    "code": "LBQ",
+    "name": "Lambarene"
+  },
+  {
+    "type": "plane",
+    "country": "Gabon",
+    "country-code": "GAB",
+    "code": "LBV",
+    "name": "Libreville"
+  },
+  {
+    "type": "plane",
+    "country": "Gabon",
+    "country-code": "GAB",
+    "code": "MFF",
+    "name": "Moanda"
+  },
+  {
+    "type": "plane",
+    "country": "Gabon",
+    "country-code": "GAB",
+    "code": "MJL",
+    "name": "Mouila"
+  },
+  {
+    "type": "plane",
+    "country": "Gabon",
+    "country-code": "GAB",
+    "code": "MVB",
+    "name": "Mvengue"
+  },
+  {
+    "type": "plane",
+    "country": "Gabon",
+    "country-code": "GAB",
+    "code": "UVE",
+    "name": "Oyem"
+  },
+  {
+    "type": "plane",
+    "country": "Gabon",
+    "country-code": "GAB",
+    "code": "POG",
+    "name": "Port Gentil"
+  },
+  {
+    "type": "plane",
+    "country": "Gambia",
+    "country-code": "GMB",
+    "code": "BJL",
+    "name": "Banjul"
+  },
+  {
+    "type": "plane",
+    "country": "Georgia",
+    "country-code": "GEO",
+    "code": "TBS",
+    "name": "Tbilisi - Novo Alexeyevka"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "AGB",
+    "name": "Augsburg"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "BYU",
+    "name": "Bayreuth"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "BER",
+    "name": "Berlin"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "SXF",
+    "name": "Berlin, Schoenefeld"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "TXL",
+    "name": "Berlin, Tegel"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "THF",
+    "name": "Berlin, Tempelhof"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "BRE",
+    "name": "Bremen"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "CGN",
+    "name": "Cologne (Koeln)/Bonn"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "DTM",
+    "name": "Dortmund"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "DRS",
+    "name": "Dresden"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "DUS",
+    "name": "Duesseldorf"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "ERF",
+    "name": "Erfurt"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "HNN",
+    "name": "Frankfurt/Hahn"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "FRA",
+    "name": "Frankfurt/Main Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "FDH",
+    "name": "Friedrichshafen"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "HAM",
+    "name": "Hamburg - Fuhlsbuettel"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "HAJ",
+    "name": "Hannover"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "HOQ",
+    "name": "Hof"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "FKB",
+    "name": "Karlsruhe/Baden-Baden"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "KEL",
+    "name": "Kiel - Holtenau"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "LEJ",
+    "name": "Leipzig"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "FMO",
+    "name": "Muenster/Osnabrueck"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "MSR",
+    "name": "Muenster/Osnabrueck"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "MUC",
+    "name": "Munchen(Munich)-FranzJose"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "NUE",
+    "name": "Nurnberg (Nuremberg)"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "PAD",
+    "name": "Paderborn/Lippstadt"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "SCN",
+    "name": "Saarbruecken"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "STR",
+    "name": "Stuttgart - Echterdingen"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "GWT",
+    "name": "Westerland"
+  },
+  {
+    "type": "plane",
+    "country": "Germany",
+    "country-code": "DEU",
+    "code": "WIE",
+    "name": "Wiesbaden, Air Base"
+  },
+  {
+    "type": "plane",
+    "country": "Ghana",
+    "country-code": "GHA",
+    "code": "ACC",
+    "name": "Accra"
+  },
+  {
+    "type": "plane",
+    "country": "Gibraltar",
+    "country-code": "GIB",
+    "code": "GIB",
+    "name": "Gibraltar"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "GPA",
+    "name": "Araxos"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "ATH",
+    "name": "Athens"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "HEW",
+    "name": "Athens, Hellinikon"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "CHQ",
+    "name": "Chania"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "JKH",
+    "name": "Chios"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "CFU",
+    "name": "Corfu"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "HER",
+    "name": "Heraklion"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "KLX",
+    "name": "Kalamata"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "AOK",
+    "name": "Karpathos"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "KVA",
+    "name": "Kavalla"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "KGS",
+    "name": "Kos"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "JMK",
+    "name": "Mykonos"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "MJT",
+    "name": "Mytilene (Lesbos)"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "PVK",
+    "name": "Preveza/Lefkas"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "RHO",
+    "name": "Rhodos"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "SMI",
+    "name": "Samos"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "JSI",
+    "name": "Skiathos"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "SKG",
+    "name": "Thessaloniki - Makedonia"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "JTR",
+    "name": "Thira"
+  },
+  {
+    "type": "plane",
+    "country": "Greece",
+    "country-code": "GRC",
+    "code": "ZTH",
+    "name": "Zakynthos"
+  },
+  {
+    "type": "plane",
+    "country": "Greenland",
+    "country-code": "GRL",
+    "code": "UAK",
+    "name": "Narsarsuaq"
+  },
+  {
+    "type": "plane",
+    "country": "Greenland",
+    "country-code": "GRL",
+    "code": "SFJ",
+    "name": "Soendre Stroemfjord"
+  },
+  {
+    "type": "plane",
+    "country": "Grenada",
+    "country-code": "GRD",
+    "code": "GND",
+    "name": "Grenada"
+  },
+  {
+    "type": "plane",
+    "country": "Guadeloupe",
+    "country-code": "GLP",
+    "code": "PTP",
+    "name": "Pointe a Pitre"
+  },
+  {
+    "type": "plane",
+    "country": "Guam",
+    "country-code": "GUM",
+    "code": "SUM",
+    "name": "Agana"
+  },
+  {
+    "type": "plane",
+    "country": "Guam",
+    "country-code": "GUM",
+    "code": "GUM",
+    "name": "Guam"
+  },
+  {
+    "type": "plane",
+    "country": "Guatemala",
+    "country-code": "GTM",
+    "code": "GUA",
+    "name": "Guatemala City"
+  },
+  {
+    "type": "plane",
+    "country": "Guinea",
+    "country-code": "GIN",
+    "code": "CKY",
+    "name": "Conakry"
+  },
+  {
+    "type": "plane",
+    "country": "Guinea",
+    "country-code": "GIN",
+    "code": "LEK",
+    "name": "Labe"
+  },
+  {
+    "type": "plane",
+    "country": "Guinea-Bissau",
+    "country-code": "GNB",
+    "code": "BXO",
+    "name": "Bissau"
+  },
+  {
+    "type": "plane",
+    "country": "Guyana",
+    "country-code": "GUY",
+    "code": "GEO",
+    "name": "Georgetown"
+  },
+  {
+    "type": "plane",
+    "country": "Haiti",
+    "country-code": "HTI",
+    "code": "PAP",
+    "name": "Port au Prince"
+  },
+  {
+    "type": "plane",
+    "country": "Honduras",
+    "country-code": "HND",
+    "code": "RTB",
+    "name": "Roatan"
+  },
+  {
+    "type": "plane",
+    "country": "Honduras",
+    "country-code": "HND",
+    "code": "SAP",
+    "name": "San Pedro Sula"
+  },
+  {
+    "type": "plane",
+    "country": "Honduras",
+    "country-code": "HND",
+    "code": "TGU",
+    "name": "Tegucigalpa"
+  },
+  {
+    "type": "plane",
+    "country": "Hong Kong",
+    "country-code": "HKG",
+    "code": "ZJK",
+    "name": "Hong Kong - Chek Lap Kok"
+  },
+  {
+    "type": "plane",
+    "country": "Hong Kong",
+    "country-code": "HKG",
+    "code": "HKG",
+    "name": "Hong Kong - Intl (HKI)"
+  },
+  {
+    "type": "plane",
+    "country": "Hungary",
+    "country-code": "HUN",
+    "code": "BUD",
+    "name": "Budapest, Ferihegy"
+  },
+  {
+    "type": "plane",
+    "country": "Iceland",
+    "country-code": "ISL",
+    "code": "CXI",
+    "name": "Christmas Line"
+  },
+  {
+    "type": "plane",
+    "country": "Iceland",
+    "country-code": "ISL",
+    "code": "EGS",
+    "name": "Egilsstadir"
+  },
+  {
+    "type": "plane",
+    "country": "Iceland",
+    "country-code": "ISL",
+    "code": "KEF",
+    "name": "Reykjavik-Keflavik Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Iceland",
+    "country-code": "ISL",
+    "code": "REK",
+    "name": "Reykjavik-Metropolitan"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "AMD",
+    "name": "Ahmedabad"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "ATQ",
+    "name": "Amritsar"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "QNB",
+    "name": "Anand"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "BLR",
+    "name": "Bangalore"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "BDQ",
+    "name": "Baronda"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "IXG",
+    "name": "Belgaum"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "BHO",
+    "name": "Bhopal"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "BBI",
+    "name": "Bhubaneswar"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "BOM",
+    "name": "Bombay"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "CCU",
+    "name": "Calcutta (Kolkata)"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "CCJ",
+    "name": "Calicut"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "IXC",
+    "name": "Chandigarh"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "COK",
+    "name": "Cochin"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "CJB",
+    "name": "Coimbatore"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "DEL",
+    "name": "Delhi, Indira Gandhi"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "GOI",
+    "name": "Goa"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "GAU",
+    "name": "Guwahati"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "HYD",
+    "name": "Hyderabad - Begumpet"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "JAI",
+    "name": "Jaipur - Sanganeer"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "JLR",
+    "name": "Jalandhar"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "IXW",
+    "name": "Jamshedpur"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "QJU",
+    "name": "Kanpur"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "LKO",
+    "name": "Lucknow"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "MAA",
+    "name": "Madras (Chennai)"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "NAG",
+    "name": "Nagpur"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "PAT",
+    "name": "Patna"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "PNQ",
+    "name": "Pune"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "RAJ",
+    "name": "Rajkot"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "IXR",
+    "name": "Ranchi"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "SXR",
+    "name": "Srinagar"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "STV",
+    "name": "Surat"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "TRV",
+    "name": "Thiruvananthapuram"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "TRZ",
+    "name": "Tiruchirapally"
+  },
+  {
+    "type": "plane",
+    "country": "India",
+    "country-code": "IND",
+    "code": "VNS",
+    "name": "Varanasi"
+  },
+  {
+    "type": "plane",
+    "country": "Indonesia",
+    "country-code": "IDN",
+    "code": "DPS",
+    "name": "Denpasar/Bali"
+  },
+  {
+    "type": "plane",
+    "country": "Indonesia",
+    "country-code": "IDN",
+    "code": "JKT",
+    "name": "Jakarta - Kemayoran"
+  },
+  {
+    "type": "plane",
+    "country": "Indonesia",
+    "country-code": "IDN",
+    "code": "CGK",
+    "name": "Jakarta - Soekarno Hatta"
+  },
+  {
+    "type": "plane",
+    "country": "Indonesia",
+    "country-code": "IDN",
+    "code": "HLP",
+    "name": "Jakarta-HalimPerdanakusma"
+  },
+  {
+    "type": "plane",
+    "country": "Indonesia",
+    "country-code": "IDN",
+    "code": "MDC",
+    "name": "Manado"
+  },
+  {
+    "type": "plane",
+    "country": "Indonesia",
+    "country-code": "IDN",
+    "code": "MES",
+    "name": "Medan"
+  },
+  {
+    "type": "plane",
+    "country": "Indonesia",
+    "country-code": "IDN",
+    "code": "SUB",
+    "name": "Surabaya - Juanda"
+  },
+  {
+    "type": "plane",
+    "country": "Indonesia",
+    "country-code": "IDN",
+    "code": "TOD",
+    "name": "Tioman"
+  },
+  {
+    "type": "plane",
+    "country": "Indonesia",
+    "country-code": "IDN",
+    "code": "UPG",
+    "name": "Ujung Pandang"
+  },
+  {
+    "type": "plane",
+    "country": "Iran",
+    "country-code": "IRN",
+    "code": "ABD",
+    "name": "Abadan"
+  },
+  {
+    "type": "plane",
+    "country": "Iran",
+    "country-code": "IRN",
+    "code": "THR",
+    "name": "Tehran (Teheran)-Mehrabad"
+  },
+  {
+    "type": "plane",
+    "country": "Iraq",
+    "country-code": "IRQ",
+    "code": "BGW",
+    "name": "Bagdad, Metropolitan Area"
+  },
+  {
+    "type": "plane",
+    "country": "Ireland",
+    "country-code": "IRL",
+    "code": "ORK",
+    "name": "Cork"
+  },
+  {
+    "type": "plane",
+    "country": "Ireland",
+    "country-code": "IRL",
+    "code": "DUB",
+    "name": "Dublin"
+  },
+  {
+    "type": "plane",
+    "country": "Ireland",
+    "country-code": "IRL",
+    "code": "GWY",
+    "name": "Galway"
+  },
+  {
+    "type": "plane",
+    "country": "Ireland",
+    "country-code": "IRL",
+    "code": "KIR",
+    "name": "Kerry County"
+  },
+  {
+    "type": "plane",
+    "country": "Ireland",
+    "country-code": "IRL",
+    "code": "NOC",
+    "name": "Knock"
+  },
+  {
+    "type": "plane",
+    "country": "Ireland",
+    "country-code": "IRL",
+    "code": "SNN",
+    "name": "Shannon (Limerick)"
+  },
+  {
+    "type": "plane",
+    "country": "Ireland",
+    "country-code": "IRL",
+    "code": "SXL",
+    "name": "Sligo"
+  },
+  {
+    "type": "plane",
+    "country": "Israel",
+    "country-code": "ISR",
+    "code": "ETH",
+    "name": "Elat"
+  },
+  {
+    "type": "plane",
+    "country": "Israel",
+    "country-code": "ISR",
+    "code": "VDA",
+    "name": "Elat, Ovula"
+  },
+  {
+    "type": "plane",
+    "country": "Israel",
+    "country-code": "ISR",
+    "code": "HFA",
+    "name": "Haifa"
+  },
+  {
+    "type": "plane",
+    "country": "Israel",
+    "country-code": "ISR",
+    "code": "JRS",
+    "name": "Jerusalem"
+  },
+  {
+    "type": "plane",
+    "country": "Israel",
+    "country-code": "ISR",
+    "code": "TLV",
+    "name": "Tel Aviv-Ben Gurion Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "AHO",
+    "name": "Alghero Sassari"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "AOI",
+    "name": "Ancona"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "BRI",
+    "name": "Bari"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "BGY 1",
+    "name": "Bergamo"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "BLQ",
+    "name": "Bologna"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "BDS",
+    "name": "Brindisi"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "CAG",
+    "name": "Cagliari"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "CTA",
+    "name": "Catania"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "FLR",
+    "name": "Florence"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "GOA",
+    "name": "Genoa"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "SUF",
+    "name": "Lamezia Terme"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "LMP",
+    "name": "Lampedusa"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "MIL",
+    "name": "Milan"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "LIN",
+    "name": "Milan - Linate"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "MXP",
+    "name": "Milan - Malpensa"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "BGY 2",
+    "name": "Milan - Orio Al Serio"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "NAP",
+    "name": "Naples"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "OLB",
+    "name": "Olbia"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "PMO",
+    "name": "Palermo - Punta Raisi"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "PNL",
+    "name": "Pantelleria"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "PEG",
+    "name": "Perugia"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "PSR",
+    "name": "Pescara"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "PSA",
+    "name": "Pisa - Gal Galilei"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "REG",
+    "name": "Reggio Calabria"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "RMI",
+    "name": "Rimini"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "ROM",
+    "name": "Rome"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "CIA",
+    "name": "Rome - Ciampino"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "FCO",
+    "name": "Rome - Fuimicino"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "TPS",
+    "name": "Trapani"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "TSF",
+    "name": "Treviso"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "TRS",
+    "name": "Trieste"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "TRN",
+    "name": "Turin"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "VCE",
+    "name": "Venice - Marco Polo"
+  },
+  {
+    "type": "plane",
+    "country": "Italy",
+    "country-code": "ITA",
+    "code": "VRN",
+    "name": "Verona"
+  },
+  {
+    "type": "plane",
+    "country": "Ivory Coast",
+    "country-code": "CIV",
+    "code": "ABJ",
+    "name": "Abidjan"
+  },
+  {
+    "type": "plane",
+    "country": "Ivory Coast",
+    "country-code": "CIV",
+    "code": "BYK",
+    "name": "Bouake"
+  },
+  {
+    "type": "plane",
+    "country": "Ivory Coast",
+    "country-code": "CIV",
+    "code": "DJO",
+    "name": "Daloa"
+  },
+  {
+    "type": "plane",
+    "country": "Ivory Coast",
+    "country-code": "CIV",
+    "code": "HGO",
+    "name": "Korhogo"
+  },
+  {
+    "type": "plane",
+    "country": "Ivory Coast",
+    "country-code": "CIV",
+    "code": "MJC",
+    "name": "Man"
+  },
+  {
+    "type": "plane",
+    "country": "Ivory Coast",
+    "country-code": "CIV",
+    "code": "SPY",
+    "name": "San Pedro"
+  },
+  {
+    "type": "plane",
+    "country": "Ivory Coast",
+    "country-code": "CIV",
+    "code": "ZSS",
+    "name": "Sassandra"
+  },
+  {
+    "type": "plane",
+    "country": "Ivory Coast",
+    "country-code": "CIV",
+    "code": "ASK",
+    "name": "Yamoussoukro"
+  },
+  {
+    "type": "plane",
+    "country": "Jamaica",
+    "country-code": "JAM",
+    "code": "KIN",
+    "name": "Kingston - Norman Manley"
+  },
+  {
+    "type": "plane",
+    "country": "Jamaica",
+    "country-code": "JAM",
+    "code": "MBJ",
+    "name": "Montenego Bay"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "ASJ",
+    "name": "Amami"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "FUK",
+    "name": "Fukuoka"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "HAC",
+    "name": "Hachijo Jima"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "HKD",
+    "name": "Hakodate"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "LSG",
+    "name": "Ishigaki"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "KOJ",
+    "name": "Kagoshima"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "UKB",
+    "name": "Kobe"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "KCZ",
+    "name": "Kochi"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "KMJ",
+    "name": "Kumamoto"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "KUH",
+    "name": "Kushiro"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "UKY",
+    "name": "Kyoto"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "MYJ",
+    "name": "Matsuyama"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "MMY",
+    "name": "MiyakoJima-Ryuku Islands"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "NGS",
+    "name": "Nagasaki"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "NGO",
+    "name": "Nagoya - Komaki AFB"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "KIJ",
+    "name": "Niigata"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "OIT",
+    "name": "Oita"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "OKA",
+    "name": "Okinawa,Ryukyo Isl'd-Naha"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "OSA",
+    "name": "Osaka"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "KIX",
+    "name": "Osaka - Kansai Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "SPK",
+    "name": "Sapporo"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "OKD",
+    "name": "Sapporo - Okadama"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "CTS",
+    "name": "Sapporo-Shin-Chitose"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "SDJ",
+    "name": "Sendai"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "TAK",
+    "name": "Takamatsu"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "TKS",
+    "name": "Tokushima"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "TYO",
+    "name": "Tokyo"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "HND",
+    "name": "Tokyo - Haneda"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "NRT",
+    "name": "Tokyo - Narita"
+  },
+  {
+    "type": "plane",
+    "country": "Japan",
+    "country-code": "JPN",
+    "code": "YOK",
+    "name": "Yokohama"
+  },
+  {
+    "type": "plane",
+    "country": "Jordan",
+    "country-code": "JOR",
+    "code": "AMM",
+    "name": "Amman"
+  },
+  {
+    "type": "plane",
+    "country": "Jordan",
+    "country-code": "JOR",
+    "code": "AQJ",
+    "name": "Aqaba"
+  },
+  {
+    "type": "plane",
+    "country": "Kazakhstan",
+    "country-code": "KAZ",
+    "code": "ADX",
+    "name": "Aktyubinsk"
+  },
+  {
+    "type": "plane",
+    "country": "Kazakhstan",
+    "country-code": "KAZ",
+    "code": "ALA",
+    "name": "Alma Ata"
+  },
+  {
+    "type": "plane",
+    "country": "Kenya",
+    "country-code": "KEN",
+    "code": "MYD",
+    "name": "Malindi"
+  },
+  {
+    "type": "plane",
+    "country": "Kenya",
+    "country-code": "KEN",
+    "code": "MBA",
+    "name": "Mombasa-Moi International"
+  },
+  {
+    "type": "plane",
+    "country": "Kenya",
+    "country-code": "KEN",
+    "code": "NBO",
+    "name": "Nairobi"
+  },
+  {
+    "type": "plane",
+    "country": "Kosovo",
+    "country-code": "UNK",
+    "code": "PRN",
+    "name": "Pristina"
+  },
+  {
+    "type": "plane",
+    "country": "Kuwait",
+    "country-code": "KWT",
+    "code": "KWI",
+    "name": "Kuwait - Kuwait Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Laos",
+    "country-code": "LAO",
+    "code": "VTE",
+    "name": "Vientiane - Wattay"
+  },
+  {
+    "type": "plane",
+    "country": "Latvia",
+    "country-code": "LVA",
+    "code": "RIX",
+    "name": "Riga"
+  },
+  {
+    "type": "plane",
+    "country": "Lebanon",
+    "country-code": "LBN",
+    "code": "BEY",
+    "name": "Beirut"
+  },
+  {
+    "type": "plane",
+    "country": "Lebanon",
+    "country-code": "LBN",
+    "code": "GJN",
+    "name": "Jounieh"
+  },
+  {
+    "type": "plane",
+    "country": "Lesotho",
+    "country-code": "LSO",
+    "code": "MSU",
+    "name": "Maseru - Moshoeshoe Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Liberia",
+    "country-code": "LBR",
+    "code": "MLW",
+    "name": "Monrovia"
+  },
+  {
+    "type": "plane",
+    "country": "Liberia",
+    "country-code": "LBR",
+    "code": "ROB",
+    "name": "Monrovia - Roberts Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Libya",
+    "country-code": "LBY",
+    "code": "BEN",
+    "name": "Bengasi"
+  },
+  {
+    "type": "plane",
+    "country": "Libya",
+    "country-code": "LBY",
+    "code": "SEB",
+    "name": "Sehba"
+  },
+  {
+    "type": "plane",
+    "country": "Libya",
+    "country-code": "LBY",
+    "code": "TIP",
+    "name": "Tripoli - Tripoli Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Lithuania",
+    "country-code": "LTU",
+    "code": "VNO",
+    "name": "Wilna (Vilnius)"
+  },
+  {
+    "type": "plane",
+    "country": "Luxembourg",
+    "country-code": "LUX",
+    "code": "LUX",
+    "name": "Luxembourg"
+  },
+  {
+    "type": "plane",
+    "country": "Macedonia",
+    "country-code": "MKD",
+    "code": "OHD",
+    "name": "Ohrid"
+  },
+  {
+    "type": "plane",
+    "country": "Macedonia",
+    "country-code": "MKD",
+    "code": "SKP",
+    "name": "Skopje"
+  },
+  {
+    "type": "plane",
+    "country": "Madagascar",
+    "country-code": "MDG",
+    "code": "TNR",
+    "name": "Antananarivo(Tanannarive)"
+  },
+  {
+    "type": "plane",
+    "country": "Madagascar",
+    "country-code": "MDG",
+    "code": "MJN",
+    "name": "Majunga"
+  },
+  {
+    "type": "plane",
+    "country": "Malawi",
+    "country-code": "MWI",
+    "code": "BLZ",
+    "name": "Blantyre"
+  },
+  {
+    "type": "plane",
+    "country": "Malawi",
+    "country-code": "MWI",
+    "code": "LLW",
+    "name": "Lilongwe - Lilongwe Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Malaysia",
+    "country-code": "MYS",
+    "code": "BTU",
+    "name": "Bintulu"
+  },
+  {
+    "type": "plane",
+    "country": "Malaysia",
+    "country-code": "MYS",
+    "code": "JHB",
+    "name": "Johore Bahru"
+  },
+  {
+    "type": "plane",
+    "country": "Malaysia",
+    "country-code": "MYS",
+    "code": "BKI",
+    "name": "Kota Kinabalu"
+  },
+  {
+    "type": "plane",
+    "country": "Malaysia",
+    "country-code": "MYS",
+    "code": "KUL",
+    "name": "Kuala Lumpur - Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Malaysia",
+    "country-code": "MYS",
+    "code": "SZB",
+    "name": "Kuala Lumpur-SultanAbdul"
+  },
+  {
+    "type": "plane",
+    "country": "Malaysia",
+    "country-code": "MYS",
+    "code": "KUA",
+    "name": "Kuantan"
+  },
+  {
+    "type": "plane",
+    "country": "Malaysia",
+    "country-code": "MYS",
+    "code": "KCH",
+    "name": "Kuching"
+  },
+  {
+    "type": "plane",
+    "country": "Malaysia",
+    "country-code": "MYS",
+    "code": "LBU",
+    "name": "Labuan"
+  },
+  {
+    "type": "plane",
+    "country": "Malaysia",
+    "country-code": "MYS",
+    "code": "LGK",
+    "name": "Langkawi"
+  },
+  {
+    "type": "plane",
+    "country": "Malaysia",
+    "country-code": "MYS",
+    "code": "MYY",
+    "name": "Miri"
+  },
+  {
+    "type": "plane",
+    "country": "Malaysia",
+    "country-code": "MYS",
+    "code": "PEN",
+    "name": "Penang International"
+  },
+  {
+    "type": "plane",
+    "country": "Malaysia",
+    "country-code": "MYS",
+    "code": "SBW",
+    "name": "Sibu"
+  },
+  {
+    "type": "plane",
+    "country": "Malaysia",
+    "country-code": "MYS",
+    "code": "TWU",
+    "name": "Tawau"
+  },
+  {
+    "type": "plane",
+    "country": "Maldives",
+    "country-code": "MDV",
+    "code": "MLE",
+    "name": "Male - International"
+  },
+  {
+    "type": "plane",
+    "country": "Mali",
+    "country-code": "MLI",
+    "code": "BKO",
+    "name": "Bamako"
+  },
+  {
+    "type": "plane",
+    "country": "Malta",
+    "country-code": "MLT",
+    "code": "MLA",
+    "name": "Luga"
+  },
+  {
+    "type": "plane",
+    "country": "Martinique",
+    "country-code": "MTQ",
+    "code": "FDF",
+    "name": "Fort de France"
+  },
+  {
+    "type": "plane",
+    "country": "Mauritania",
+    "country-code": "MRT",
+    "code": "NDB",
+    "name": "Nouadhibou"
+  },
+  {
+    "type": "plane",
+    "country": "Mauritania",
+    "country-code": "MRT",
+    "code": "NKC",
+    "name": "Nouakchott"
+  },
+  {
+    "type": "plane",
+    "country": "Mauritania",
+    "country-code": "MRT",
+    "code": "OUZ",
+    "name": "Zouerate"
+  },
+  {
+    "type": "plane",
+    "country": "Mauritius",
+    "country-code": "MUS",
+    "code": "MRU",
+    "name": "Mauritius-Sir S.Ramgoolam"
+  },
+  {
+    "type": "plane",
+    "country": "Mauritius",
+    "country-code": "MUS",
+    "code": "RRG",
+    "name": "Rodrigues Island"
+  },
+  {
+    "type": "plane",
+    "country": "Mayotte",
+    "country-code": "MYT",
+    "code": "DZA",
+    "name": "Dzaoudzi"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "ACA",
+    "name": "Acapulco"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "AGU",
+    "name": "Aguascaliente"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "CUN",
+    "name": "Cancun"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "CZA",
+    "name": "Chichen Itza"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "CUU",
+    "name": "Chihuahua, Villalobos"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "CME",
+    "name": "Ciudad Del Carmen"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "CJS",
+    "name": "Ciudad Juarez"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "CEN",
+    "name": "Ciudad Obregon"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "CVM",
+    "name": "Ciudad Victoria"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "CLQ",
+    "name": "Colima"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "CZM",
+    "name": "Cozmel"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "CUL",
+    "name": "Culiacan"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "GDL",
+    "name": "Guadalajara"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "HMO",
+    "name": "Hermosillo-Gen.P Garcia"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "HUX",
+    "name": "Huatulco"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "ZIH",
+    "name": "Ixtapa/Zihuatenejo"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "LAP",
+    "name": "La Paz - Leon"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "LZC",
+    "name": "Lazaro Cardenas"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "BJX",
+    "name": "Leon"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "LTO",
+    "name": "Loreto"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "SJD",
+    "name": "Los Cabos"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "LMM",
+    "name": "Los Mochis"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "ZLO",
+    "name": "Manzanillo"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "MZT",
+    "name": "Mazatlan"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "MID",
+    "name": "Merida"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "MXL",
+    "name": "Mexicali"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "MEX",
+    "name": "Mexico City-Juarez Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "MTT",
+    "name": "Minatitlan"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "MTY",
+    "name": "Monterrey"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "NTR",
+    "name": "Monterrey- Del Norte"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "MLM",
+    "name": "Morelia"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "NLD",
+    "name": "Nuevo Laredo"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "OAX",
+    "name": "Oaxaca"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "PBC",
+    "name": "Puebla"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "PXM",
+    "name": "Puerto Escondido"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "PVR",
+    "name": "Puerto Vallarta"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "SLP",
+    "name": "San Luis Potosi"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "TAM",
+    "name": "Tampico-Gen.F.Javier Mina"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "TIJ",
+    "name": "Tijuana - Rodriguez"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "TGZ",
+    "name": "Tuxtla Gutierrez"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "VER",
+    "name": "Veracruz"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "VSA",
+    "name": "Villahermosa"
+  },
+  {
+    "type": "plane",
+    "country": "Mexico",
+    "country-code": "MEX",
+    "code": "ZCL",
+    "name": "Zacatecas"
+  },
+  {
+    "type": "plane",
+    "country": "Micronesia",
+    "country-code": "FSM",
+    "code": "PNI",
+    "name": "Pohnpei"
+  },
+  {
+    "type": "plane",
+    "country": "Mongolia",
+    "country-code": "MNG",
+    "code": "ULN",
+    "name": "Ulaanbaatar - Buyant Uhaa"
+  },
+  {
+    "type": "plane",
+    "country": "Montenegro",
+    "country-code": "MNE",
+    "code": "TGD",
+    "name": "Podgorica"
+  },
+  {
+    "type": "plane",
+    "country": "Montenegro",
+    "country-code": "MNE",
+    "code": "TIV",
+    "name": "Tivat"
+  },
+  {
+    "type": "plane",
+    "country": "Morocco",
+    "country-code": "MAR",
+    "code": "AGA",
+    "name": "Agadir"
+  },
+  {
+    "type": "plane",
+    "country": "Morocco",
+    "country-code": "MAR",
+    "code": "AHU",
+    "name": "Al Hoceima"
+  },
+  {
+    "type": "plane",
+    "country": "Morocco",
+    "country-code": "MAR",
+    "code": "CAS",
+    "name": "Casablanca"
+  },
+  {
+    "type": "plane",
+    "country": "Morocco",
+    "country-code": "MAR",
+    "code": "CMN",
+    "name": "Casablanca, Mohamed"
+  },
+  {
+    "type": "plane",
+    "country": "Morocco",
+    "country-code": "MAR",
+    "code": "FEZ",
+    "name": "Fes"
+  },
+  {
+    "type": "plane",
+    "country": "Morocco",
+    "country-code": "MAR",
+    "code": "RAK",
+    "name": "Marrakech - Menara"
+  },
+  {
+    "type": "plane",
+    "country": "Morocco",
+    "country-code": "MAR",
+    "code": "OZZ",
+    "name": "Ouarzazate"
+  },
+  {
+    "type": "plane",
+    "country": "Morocco",
+    "country-code": "MAR",
+    "code": "OUD",
+    "name": "Oujda"
+  },
+  {
+    "type": "plane",
+    "country": "Morocco",
+    "country-code": "MAR",
+    "code": "RBA",
+    "name": "Rabat - Sale"
+  },
+  {
+    "type": "plane",
+    "country": "Morocco",
+    "country-code": "MAR",
+    "code": "TNG",
+    "name": "Tanger - Boukhalef"
+  },
+  {
+    "type": "plane",
+    "country": "Mozambique",
+    "country-code": "MOZ",
+    "code": "BEW",
+    "name": "Beira"
+  },
+  {
+    "type": "plane",
+    "country": "Mozambique",
+    "country-code": "MOZ",
+    "code": "MPM",
+    "name": "Maputo - Maputo Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Namibia",
+    "country-code": "NAM",
+    "code": "MPA",
+    "name": "Katima Mulilo/Mpacha"
+  },
+  {
+    "type": "plane",
+    "country": "Namibia",
+    "country-code": "NAM",
+    "code": "KMP",
+    "name": "Keetmanshoop"
+  },
+  {
+    "type": "plane",
+    "country": "Namibia",
+    "country-code": "NAM",
+    "code": "LUD",
+    "name": "Luederitz"
+  },
+  {
+    "type": "plane",
+    "country": "Namibia",
+    "country-code": "NAM",
+    "code": "OKU",
+    "name": "Mokuti"
+  },
+  {
+    "type": "plane",
+    "country": "Namibia",
+    "country-code": "NAM",
+    "code": "OND",
+    "name": "Ondangwa"
+  },
+  {
+    "type": "plane",
+    "country": "Namibia",
+    "country-code": "NAM",
+    "code": "OMD",
+    "name": "Oranjemund"
+  },
+  {
+    "type": "plane",
+    "country": "Namibia",
+    "country-code": "NAM",
+    "code": "NDU",
+    "name": "Rundu"
+  },
+  {
+    "type": "plane",
+    "country": "Namibia",
+    "country-code": "NAM",
+    "code": "SWP",
+    "name": "Swakopmund"
+  },
+  {
+    "type": "plane",
+    "country": "Namibia",
+    "country-code": "NAM",
+    "code": "TSB",
+    "name": "Tsumeb"
+  },
+  {
+    "type": "plane",
+    "country": "Namibia",
+    "country-code": "NAM",
+    "code": "ERS",
+    "name": "Windhoek - Eros"
+  },
+  {
+    "type": "plane",
+    "country": "Namibia",
+    "country-code": "NAM",
+    "code": "WDH",
+    "name": "Windhoek - International"
+  },
+  {
+    "type": "plane",
+    "country": "Nepal",
+    "country-code": "NPL",
+    "code": "KTM",
+    "name": "Kathmandu - Tribhuvan"
+  },
+  {
+    "type": "plane",
+    "country": "Netherlands",
+    "country-code": "NLD",
+    "code": "AMS",
+    "name": "Amsterdam, Schiphol"
+  },
+  {
+    "type": "plane",
+    "country": "Netherlands",
+    "country-code": "NLD",
+    "code": "HAG",
+    "name": "Den Haag (The Hague)"
+  },
+  {
+    "type": "plane",
+    "country": "Netherlands",
+    "country-code": "NLD",
+    "code": "EIN",
+    "name": "Eindhoven"
+  },
+  {
+    "type": "plane",
+    "country": "Netherlands",
+    "country-code": "NLD",
+    "code": "MST",
+    "name": "Maastricht/Aachen"
+  },
+  {
+    "type": "plane",
+    "country": "Netherlands",
+    "country-code": "NLD",
+    "code": "RTM",
+    "name": "Rotterdam"
+  },
+  {
+    "type": "plane",
+    "country": "Netherlands Antilles",
+    "country-code": "ANT",
+    "code": "BON",
+    "name": "Bonaire"
+  },
+  {
+    "type": "plane",
+    "country": "Netherlands Antilles",
+    "country-code": "ANT",
+    "code": "CUR",
+    "name": "Curacao"
+  },
+  {
+    "type": "plane",
+    "country": "Netherlands Antilles",
+    "country-code": "ANT",
+    "code": "SXM",
+    "name": "St. Marteen"
+  },
+  {
+    "type": "plane",
+    "country": "New Caledonia",
+    "country-code": "NCL",
+    "code": "ILP",
+    "name": "Ile des Pins"
+  },
+  {
+    "type": "plane",
+    "country": "New Caledonia",
+    "country-code": "NCL",
+    "code": "IOU",
+    "name": "Ile Ouen"
+  },
+  {
+    "type": "plane",
+    "country": "New Caledonia",
+    "country-code": "NCL",
+    "code": "LIF",
+    "name": "Lifou"
+  },
+  {
+    "type": "plane",
+    "country": "New Caledonia",
+    "country-code": "NCL",
+    "code": "MEE",
+    "name": "Mare"
+  },
+  {
+    "type": "plane",
+    "country": "New Caledonia",
+    "country-code": "NCL",
+    "code": "NOU",
+    "name": "Noumea"
+  },
+  {
+    "type": "plane",
+    "country": "New Caledonia",
+    "country-code": "NCL",
+    "code": "TOU",
+    "name": "Touho"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "AKL",
+    "name": "Auckland"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "BHE",
+    "name": "Blenheim"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "CHC",
+    "name": "Christchurch"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "DUD",
+    "name": "Dunedin"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "IVC",
+    "name": "Incercargill"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "IVR",
+    "name": "Invercargill"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "MFN",
+    "name": "Milford Sound"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "GTN",
+    "name": "Mount Cook"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "NSN",
+    "name": "Nelson"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "PMR",
+    "name": "Palmerston North"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "ZQN",
+    "name": "Queenstown"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "RAR",
+    "name": "Rarotonga Cook"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "ROT",
+    "name": "Rotorua"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "TEU",
+    "name": "Te Anau"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "WLG",
+    "name": "Wellington"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "WHK",
+    "name": "Whakatane"
+  },
+  {
+    "type": "plane",
+    "country": "New Zealand",
+    "country-code": "NZL",
+    "code": "WRE",
+    "name": "Whangarei"
+  },
+  {
+    "type": "plane",
+    "country": "Nicaragua",
+    "country-code": "NIC",
+    "code": "MGA",
+    "name": "Managua-Augusto C Sandino"
+  },
+  {
+    "type": "plane",
+    "country": "Niger",
+    "country-code": "NER",
+    "code": "AJY",
+    "name": "Agades"
+  },
+  {
+    "type": "plane",
+    "country": "Niger",
+    "country-code": "NER",
+    "code": "RLT",
+    "name": "Arlit"
+  },
+  {
+    "type": "plane",
+    "country": "Niger",
+    "country-code": "NER",
+    "code": "MFQ",
+    "name": "Maradi"
+  },
+  {
+    "type": "plane",
+    "country": "Niger",
+    "country-code": "NER",
+    "code": "NIM",
+    "name": "Niamey"
+  },
+  {
+    "type": "plane",
+    "country": "Niger",
+    "country-code": "NER",
+    "code": "ZND",
+    "name": "Zinder"
+  },
+  {
+    "type": "plane",
+    "country": "Nigeria",
+    "country-code": "NGA",
+    "code": "KAN",
+    "name": "Kano"
+  },
+  {
+    "type": "plane",
+    "country": "Nigeria",
+    "country-code": "NGA",
+    "code": "LOS",
+    "name": "Lagos - Murtala Muhammed"
+  },
+  {
+    "type": "plane",
+    "country": "Nigeria",
+    "country-code": "NGA",
+    "code": "PHC",
+    "name": "Port Harcourt"
+  },
+  {
+    "type": "plane",
+    "country": "Northern Mariana Islands",
+    "country-code": "MNP",
+    "code": "SPN",
+    "name": "Saipan"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "AES",
+    "name": "Alesund"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "ALF",
+    "name": "Alta"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "BDU",
+    "name": "Bardufoss"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "BGO",
+    "name": "Bergen"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "BOO",
+    "name": "Bodo"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "BNN",
+    "name": "Broennoeysund"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "EVE",
+    "name": "Evenes"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "FRO",
+    "name": "Floro"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "HFT",
+    "name": "Hammerfest"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "HAU",
+    "name": "Haugesund"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "KKN",
+    "name": "Kirkenes"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "KRS",
+    "name": "Kristiansand"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "KSU",
+    "name": "Kristiansund"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "LKL",
+    "name": "Lakselv"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "LYR",
+    "name": "Longyearbyen - Svalbard"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "OSL",
+    "name": "Oslo"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "FBU",
+    "name": "Oslo - Fornebu"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "TRF",
+    "name": "Oslo - Sandefjord"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "SOG",
+    "name": "Sogndal"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "SVG",
+    "name": "Stavanger"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "TOS",
+    "name": "Tromsoe"
+  },
+  {
+    "type": "plane",
+    "country": "Norway",
+    "country-code": "NOR",
+    "code": "TRD",
+    "name": "Trondheim"
+  },
+  {
+    "type": "plane",
+    "country": "Oman",
+    "country-code": "OMN",
+    "code": "MCT",
+    "name": "Muscat - Seeb"
+  },
+  {
+    "type": "plane",
+    "country": "Oman",
+    "country-code": "OMN",
+    "code": "SLL",
+    "name": "Salalah"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "BHV",
+    "name": "Bahawalpur"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "BNP",
+    "name": "Bannu"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "CJL",
+    "name": "Chitral"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "DSK",
+    "name": "Dera Ismail Khan"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "LYP",
+    "name": "Faisalabad"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "GIL",
+    "name": "Gilgit"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "GWD",
+    "name": "Gwadar"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "HDD",
+    "name": "Hyderabad"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "ISB",
+    "name": "Islamabad-Islamabad Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "JAG",
+    "name": "Jacobabad"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "JIW",
+    "name": "Jiwani"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "KHI",
+    "name": "Karachi-Quaid-E-Azam"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "KDD",
+    "name": "Khuzdar"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "OHT",
+    "name": "Kohat"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "LHE",
+    "name": "Lahore"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "MWD",
+    "name": "Mianwali"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "QML",
+    "name": "Mirpur"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "MJD",
+    "name": "Moenjodaro"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "MUX",
+    "name": "Multan"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "MFG",
+    "name": "Muzaffarabad"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "WNS",
+    "name": "Nawab Shah"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "PJG",
+    "name": "Panjgur"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "PSI",
+    "name": "Pasni"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "PEW",
+    "name": "Peshawar"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "UET",
+    "name": "Quetta"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "RYK",
+    "name": "Rahim Yar Khan"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "RAZ",
+    "name": "Rawala Kot"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "RWP",
+    "name": "Rawalpindi"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "SDT",
+    "name": "Saidu Sharif"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "MPD",
+    "name": "Sindhri"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "KDU",
+    "name": "Skardu"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "SUL",
+    "name": "Sui"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "SKZ",
+    "name": "Sukkur"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "TUK",
+    "name": "Turbat"
+  },
+  {
+    "type": "plane",
+    "country": "Pakistan",
+    "country-code": "PAK",
+    "code": "PZH",
+    "name": "Zhob"
+  },
+  {
+    "type": "plane",
+    "country": "Panama",
+    "country-code": "PAN",
+    "code": "PTY",
+    "name": "Panama City-Tocumen Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Papua New Guinea",
+    "country-code": "PNG",
+    "code": "LAE",
+    "name": "Lae"
+  },
+  {
+    "type": "plane",
+    "country": "Papua New Guinea",
+    "country-code": "PNG",
+    "code": "MFO",
+    "name": "Manguna"
+  },
+  {
+    "type": "plane",
+    "country": "Papua New Guinea",
+    "country-code": "PNG",
+    "code": "POM",
+    "name": "Port Moresby-JacksonField"
+  },
+  {
+    "type": "plane",
+    "country": "Paraguay",
+    "country-code": "PRY",
+    "code": "ASU",
+    "name": "Asuncion"
+  },
+  {
+    "type": "plane",
+    "country": "Peru",
+    "country-code": "PER",
+    "code": "IQT",
+    "name": "Iquitos"
+  },
+  {
+    "type": "plane",
+    "country": "Peru",
+    "country-code": "PER",
+    "code": "LIM",
+    "name": "Lima - J Chavez Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Philippines",
+    "country-code": "PHL",
+    "code": "CBU",
+    "name": "Cebu"
+  },
+  {
+    "type": "plane",
+    "country": "Philippines",
+    "country-code": "PHL",
+    "code": "NOP",
+    "name": "Mactan Island - Nab"
+  },
+  {
+    "type": "plane",
+    "country": "Philippines",
+    "country-code": "PHL",
+    "code": "MNL",
+    "name": "Manila-Ninoy Aquino Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Poland",
+    "country-code": "POL",
+    "code": "GDN",
+    "name": "Gdansk"
+  },
+  {
+    "type": "plane",
+    "country": "Poland",
+    "country-code": "POL",
+    "code": "KRK",
+    "name": "Krakau"
+  },
+  {
+    "type": "plane",
+    "country": "Poland",
+    "country-code": "POL",
+    "code": "SZZ",
+    "name": "Stettin"
+  },
+  {
+    "type": "plane",
+    "country": "Poland",
+    "country-code": "POL",
+    "code": "WAW",
+    "name": "Warsaw"
+  },
+  {
+    "type": "plane",
+    "country": "Portugal",
+    "country-code": "PRT",
+    "code": "FAO",
+    "name": "Faro"
+  },
+  {
+    "type": "plane",
+    "country": "Portugal",
+    "country-code": "PRT",
+    "code": "FNC",
+    "name": "Funchal"
+  },
+  {
+    "type": "plane",
+    "country": "Portugal",
+    "country-code": "PRT",
+    "code": "HOR",
+    "name": "Horta"
+  },
+  {
+    "type": "plane",
+    "country": "Portugal",
+    "country-code": "PRT",
+    "code": "LIS",
+    "name": "Lisbon - Lisboa"
+  },
+  {
+    "type": "plane",
+    "country": "Portugal",
+    "country-code": "PRT",
+    "code": "PDL",
+    "name": "Ponta Delgada"
+  },
+  {
+    "type": "plane",
+    "country": "Portugal",
+    "country-code": "PRT",
+    "code": "OPO",
+    "name": "Porto"
+  },
+  {
+    "type": "plane",
+    "country": "Portugal",
+    "country-code": "PRT",
+    "code": "PXO",
+    "name": "Porto Santo"
+  },
+  {
+    "type": "plane",
+    "country": "Portugal",
+    "country-code": "PRT",
+    "code": "SMA",
+    "name": "Santa Maria"
+  },
+  {
+    "type": "plane",
+    "country": "Portugal",
+    "country-code": "PRT",
+    "code": "TER",
+    "name": "Terceira"
+  },
+  {
+    "type": "plane",
+    "country": "Puerto Rico",
+    "country-code": "PRI",
+    "code": "BQN",
+    "name": "Aguadilla"
+  },
+  {
+    "type": "plane",
+    "country": "Puerto Rico",
+    "country-code": "PRI",
+    "code": "MAZ",
+    "name": "Mayaguez"
+  },
+  {
+    "type": "plane",
+    "country": "Puerto Rico",
+    "country-code": "PRI",
+    "code": "PSE",
+    "name": "Ponce"
+  },
+  {
+    "type": "plane",
+    "country": "Puerto Rico",
+    "country-code": "PRI",
+    "code": "SJU",
+    "name": "San Juan Perto"
+  },
+  {
+    "type": "plane",
+    "country": "Qatar",
+    "country-code": "QAT",
+    "code": "DOH",
+    "name": "Doha"
+  },
+  {
+    "type": "plane",
+    "country": "Reunion",
+    "country-code": "REU",
+    "code": "RUN",
+    "name": "Saint Denis de la Reunion"
+  },
+  {
+    "type": "plane",
+    "country": "Romania",
+    "country-code": "ROU",
+    "code": "BUH",
+    "name": "Bucharest"
+  },
+  {
+    "type": "plane",
+    "country": "Romania",
+    "country-code": "ROU",
+    "code": "OTP",
+    "name": "Bucharest, Otopeni"
+  },
+  {
+    "type": "plane",
+    "country": "Romania",
+    "country-code": "ROU",
+    "code": "CND",
+    "name": "Constanza"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "AER",
+    "name": "Adler/Sochi"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "KHV",
+    "name": "Chabarovsk (Khabarovsk)"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "HTA",
+    "name": "Chita (Tschita)"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "IKT",
+    "name": "Irkutsk"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "KZN",
+    "name": "Kazan (Ka San)"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "MRV",
+    "name": "Mineralnye Vody"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "DME",
+    "name": "Moscow - Domodedovo"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "SVO",
+    "name": "Moscow - Sheremetyevo"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "VKO",
+    "name": "Moscow - Vnukovo"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "MOW",
+    "name": "Moscow -Metropolitan Area"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "MMK",
+    "name": "Murmansk"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "OVB",
+    "name": "Novosibirsk - Tolmachevo"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "LED",
+    "name": "St. Petersburg - Pulkovo"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "UUD",
+    "name": "Ulan-Ude"
+  },
+  {
+    "type": "plane",
+    "country": "Russia",
+    "country-code": "RUS",
+    "code": "VLU",
+    "name": "Velikiye Luki (Welikije)"
+  },
+  {
+    "type": "plane",
+    "country": "Rwanda",
+    "country-code": "RWA",
+    "code": "KGL",
+    "name": "Kigali-Gregoire Kayibanda"
+  },
+  {
+    "type": "plane",
+    "country": "Samoa & Western Samoa",
+    "country-code": "WSM",
+    "code": "APW",
+    "name": "Apia"
+  },
+  {
+    "type": "plane",
+    "country": "Sao Tome And Principe",
+    "country-code": "STP",
+    "code": "TMS",
+    "name": "Sao Tome"
+  },
+  {
+    "type": "plane",
+    "country": "Saudi Arabia",
+    "country-code": "SAU",
+    "code": "DHA",
+    "name": "Dhahran"
+  },
+  {
+    "type": "plane",
+    "country": "Saudi Arabia",
+    "country-code": "SAU",
+    "code": "JED",
+    "name": "Jeddah-King Abdulaziz"
+  },
+  {
+    "type": "plane",
+    "country": "Saudi Arabia",
+    "country-code": "SAU",
+    "code": "AHB",
+    "name": "Khamis Mushayat"
+  },
+  {
+    "type": "plane",
+    "country": "Saudi Arabia",
+    "country-code": "SAU",
+    "code": "MED",
+    "name": "Medina"
+  },
+  {
+    "type": "plane",
+    "country": "Saudi Arabia",
+    "country-code": "SAU",
+    "code": "RUH",
+    "name": "Riyadh - King Khaled"
+  },
+  {
+    "type": "plane",
+    "country": "Saudi Arabia",
+    "country-code": "SAU",
+    "code": "TUU",
+    "name": "Tabuk"
+  },
+  {
+    "type": "plane",
+    "country": "Saudi Arabia",
+    "country-code": "SAU",
+    "code": "TIF",
+    "name": "Taif"
+  },
+  {
+    "type": "plane",
+    "country": "Saudi Arabia",
+    "country-code": "SAU",
+    "code": "YNB",
+    "name": "Yanbu"
+  },
+  {
+    "type": "plane",
+    "country": "Senegal",
+    "country-code": "SEN",
+    "code": "DKR",
+    "name": "Dakar"
+  },
+  {
+    "type": "plane",
+    "country": "Serbia",
+    "country-code": "SRB",
+    "code": "BEG",
+    "name": "Belgrade (Beograd)"
+  },
+  {
+    "type": "plane",
+    "country": "Serbia",
+    "country-code": "SRB",
+    "code": "INI",
+    "name": "Nis"
+  },
+  {
+    "type": "plane",
+    "country": "Serbia",
+    "country-code": "SRB",
+    "code": "QND",
+    "name": "Novi Sad"
+  },
+  {
+    "type": "plane",
+    "country": "Seychelles",
+    "country-code": "SYC",
+    "code": "SEZ",
+    "name": "Mahe - Seychelles Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Sierra Leone",
+    "country-code": "SLE",
+    "code": "FNA",
+    "name": "Freetown"
+  },
+  {
+    "type": "plane",
+    "country": "Singapore",
+    "country-code": "SGP",
+    "code": "SIN",
+    "name": "Singapore - Changi"
+  },
+  {
+    "type": "plane",
+    "country": "Slovakia",
+    "country-code": "SVK",
+    "code": "BTS",
+    "name": "Bratislava"
+  },
+  {
+    "type": "plane",
+    "country": "Slovenia",
+    "country-code": "SVN",
+    "code": "LJU",
+    "name": "Ljubljana - Brnik"
+  },
+  {
+    "type": "plane",
+    "country": "Slovenia",
+    "country-code": "SVN",
+    "code": "MBX",
+    "name": "Maribor"
+  },
+  {
+    "type": "plane",
+    "country": "Somalia",
+    "country-code": "SOM",
+    "code": "MGQ",
+    "name": "Mogadischu"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "AGZ",
+    "name": "Aggeneys"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "ALJ",
+    "name": "Alexander Bay"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "ADY",
+    "name": "Alldays"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "BFN",
+    "name": "Bloemfontein"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "CPT",
+    "name": "Cape Town"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "DUR",
+    "name": "Durban"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "ELS",
+    "name": "East London"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "ELL",
+    "name": "Ellisras"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "GRJ",
+    "name": "George"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "JNB",
+    "name": "Johannesburg Int."
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "KIM",
+    "name": "Kimberley"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "KLZ",
+    "name": "Kleinsee"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "HLA",
+    "name": "Lanseria"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "LUJ",
+    "name": "Lusisiki"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "MGH",
+    "name": "Margate"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "MEZ",
+    "name": "Messina"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "MBM",
+    "name": "Mkambati"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "MZF",
+    "name": "Mzamba"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "NLP",
+    "name": "Nelspruit"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "MQP",
+    "name": "Nelspruit-KrugerMpumalang"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "NCS",
+    "name": "Newcastle"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "OUH",
+    "name": "Oudtshoorn"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "PHW",
+    "name": "Phalaborwa"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "PZB",
+    "name": "Pietermaritzburg"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "PTG",
+    "name": "Pietersburg"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "NTY",
+    "name": "Pilanesberg/Sun City"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "PBZ",
+    "name": "Plettenberg Bay"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "PLZ",
+    "name": "Port Elizabeth"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "PRY",
+    "name": "Pretoria-Wonderboom"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "RCB",
+    "name": "Richards Bay"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "SIS",
+    "name": "Sishen"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "SZK",
+    "name": "Skukuza"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "SBU",
+    "name": "Springbok"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "TCU",
+    "name": "Thaba'Nchu"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "ULD",
+    "name": "Ulundi"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "UTT",
+    "name": "Umtata"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "UTN",
+    "name": "Upington"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "VYD",
+    "name": "Vryheid"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "WVB",
+    "name": "Walvis Bay"
+  },
+  {
+    "type": "plane",
+    "country": "South Africa",
+    "country-code": "ZAF",
+    "code": "WEL",
+    "name": "Welkom"
+  },
+  {
+    "type": "plane",
+    "country": "South Korea",
+    "country-code": "KOR",
+    "code": "SEL",
+    "name": "Seoul - Kimpo"
+  },
+  {
+    "type": "plane",
+    "country": "South Korea",
+    "country-code": "KOR",
+    "code": "ICN",
+    "name": "Seoul-Incheon Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "ALC",
+    "name": "Alicante"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "LEI",
+    "name": "Almeria"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "ACE",
+    "name": "Arrecife/Lanzarote"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "BJZ",
+    "name": "Badajoz"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "BCN",
+    "name": "Barcelona - El Prat"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "BIO",
+    "name": "Bilbao"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "ODB",
+    "name": "Cordoba"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "FUE",
+    "name": "Fuerteventura"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "GRO",
+    "name": "Gerona"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "GRX",
+    "name": "Granada"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "IBZ",
+    "name": "Ibiza"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "XRY",
+    "name": "Jerez de la Frontera"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "LCG",
+    "name": "La Coruna"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "LPA",
+    "name": "Las Palmas"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "MAD",
+    "name": "Madrid - Barajas"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "MAH",
+    "name": "Mahon"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "AGP",
+    "name": "Malaga"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "MJV",
+    "name": "Murcia"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "OVD",
+    "name": "Oviedo"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "PMI",
+    "name": "Palma de Mallorca"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "REU",
+    "name": "Reus"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "EAS",
+    "name": "San Sebastian"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "SPC",
+    "name": "Santa Cruz de la Palma"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "SDR",
+    "name": "Santander"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "SCQ",
+    "name": "Santiago de Compostela"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "SVQ",
+    "name": "Sevilla"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "TCI",
+    "name": "Tenerife"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "TFN",
+    "name": "Tenerife-Norte Los Rodeos"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "TFS",
+    "name": "Tenerife-Sur Reina Sofia"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "VLC",
+    "name": "Valencia"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "VLL",
+    "name": "Valladolid"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "VDE",
+    "name": "Valverde"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "VGO",
+    "name": "Vigo"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "VIT",
+    "name": "Vitoria"
+  },
+  {
+    "type": "plane",
+    "country": "Spain",
+    "country-code": "ESP",
+    "code": "ZAZ",
+    "name": "Zaragoza"
+  },
+  {
+    "type": "plane",
+    "country": "Sri Lanka",
+    "country-code": "LKA",
+    "code": "CMB",
+    "name": "Colombo"
+  },
+  {
+    "type": "plane",
+    "country": "St Kitts And Nevis",
+    "country-code": "KNA",
+    "code": "NEV",
+    "name": "Nevis"
+  },
+  {
+    "type": "plane",
+    "country": "St Kitts And Nevis",
+    "country-code": "KNA",
+    "code": "SKB",
+    "name": "St. Kitts"
+  },
+  {
+    "type": "plane",
+    "country": "St Lucia",
+    "country-code": "LCA",
+    "code": "UVF",
+    "name": "St. Lucia Hewanorra"
+  },
+  {
+    "type": "plane",
+    "country": "St Lucia",
+    "country-code": "LCA",
+    "code": "SLU",
+    "name": "St. Lucia Vigle"
+  },
+  {
+    "type": "plane",
+    "country": "St Vincent",
+    "country-code": "VCT",
+    "code": "SVD",
+    "name": "St. Vincent"
+  },
+  {
+    "type": "plane",
+    "country": "St. Martin",
+    "country-code": "SXM",
+    "code": "SFG",
+    "name": "St. Martin"
+  },
+  {
+    "type": "plane",
+    "country": "Sudan",
+    "country-code": "SDN",
+    "code": "KSL",
+    "name": "Kassala"
+  },
+  {
+    "type": "plane",
+    "country": "Sudan",
+    "country-code": "SDN",
+    "code": "KRT",
+    "name": "Khartoum"
+  },
+  {
+    "type": "plane",
+    "country": "Surinam",
+    "country-code": "SUR",
+    "code": "PBM",
+    "name": "Paramaribo-Zanderij Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Swaziland",
+    "country-code": "SWZ",
+    "code": "MTS",
+    "name": "Manzini - Matsapha Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "GOT",
+    "name": "Goteborg"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "JHE",
+    "name": "Helsingborg"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "JKG",
+    "name": "Joenkoeping"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "KLR",
+    "name": "Kalmar"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "KSD",
+    "name": "Karlstad"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "KRN",
+    "name": "Kiruna"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "KTT",
+    "name": "Kittilae"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "KID",
+    "name": "Kristianstad"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "LDK",
+    "name": "Lidkoeping"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "LLA",
+    "name": "Lulea"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "MMA",
+    "name": "Malmo (Malmoe)"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "MMX",
+    "name": "Malmo (Malmoe) - Sturup"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "NRK",
+    "name": "Norrkoeping"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "ORB",
+    "name": "Oerebro"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "RNB",
+    "name": "Ronneby"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "ARN",
+    "name": "Stockholm - Arlanda"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "BMA",
+    "name": "Stockholm - Bromma"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "STO",
+    "name": "Stockholm - Metropol Area"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "SDL",
+    "name": "Sundsvall"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "VXO",
+    "name": "Vaexjoe"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "VST",
+    "name": "Vasteras"
+  },
+  {
+    "type": "plane",
+    "country": "Sweden",
+    "country-code": "SWE",
+    "code": "VBY",
+    "name": "Visby"
+  },
+  {
+    "type": "plane",
+    "country": "Switzerland",
+    "country-code": "CHE",
+    "code": "ACH",
+    "name": "Altenrhein"
+  },
+  {
+    "type": "plane",
+    "country": "Switzerland",
+    "country-code": "CHE",
+    "code": "BSL",
+    "name": "Basel"
+  },
+  {
+    "type": "plane",
+    "country": "Switzerland",
+    "country-code": "CHE",
+    "code": "EAP",
+    "name": "Basel/Mulhouse"
+  },
+  {
+    "type": "plane",
+    "country": "Switzerland",
+    "country-code": "CHE",
+    "code": "BRN",
+    "name": "Bern"
+  },
+  {
+    "type": "plane",
+    "country": "Switzerland",
+    "country-code": "CHE",
+    "code": "ZDJ",
+    "name": "Bern"
+  },
+  {
+    "type": "plane",
+    "country": "Switzerland",
+    "country-code": "CHE",
+    "code": "GVA",
+    "name": "Geneva"
+  },
+  {
+    "type": "plane",
+    "country": "Switzerland",
+    "country-code": "CHE",
+    "code": "LUG",
+    "name": "Lugano"
+  },
+  {
+    "type": "plane",
+    "country": "Switzerland",
+    "country-code": "CHE",
+    "code": "ZRH",
+    "name": "Zurich (Zurich) - Kloten"
+  },
+  {
+    "type": "plane",
+    "country": "Syria",
+    "country-code": "SYR",
+    "code": "ALP",
+    "name": "Aleppo"
+  },
+  {
+    "type": "plane",
+    "country": "Syria",
+    "country-code": "SYR",
+    "code": "DAM",
+    "name": "Damaskus"
+  },
+  {
+    "type": "plane",
+    "country": "Taiwan",
+    "country-code": "TWN",
+    "code": "KHH",
+    "name": "Kaohsiung Intl"
+  },
+  {
+    "type": "plane",
+    "country": "Taiwan",
+    "country-code": "TWN",
+    "code": "MZG",
+    "name": "Makung"
+  },
+  {
+    "type": "plane",
+    "country": "Taiwan",
+    "country-code": "TWN",
+    "code": "TPE",
+    "name": "Taipei - Chiang Kai Shek"
+  },
+  {
+    "type": "plane",
+    "country": "Taiwan",
+    "country-code": "TWN",
+    "code": "TAY",
+    "name": "Taipei - Sung Shan"
+  },
+  {
+    "type": "plane",
+    "country": "Tajikistan",
+    "country-code": "TJK",
+    "code": "DYU",
+    "name": "Dushanbe (Duschanbe)"
+  },
+  {
+    "type": "plane",
+    "country": "Tanzania",
+    "country-code": "TZA",
+    "code": "ARK",
+    "name": "Arusha"
+  },
+  {
+    "type": "plane",
+    "country": "Tanzania",
+    "country-code": "TZA",
+    "code": "DAR",
+    "name": "Dar es Salam (Daressalam)"
+  },
+  {
+    "type": "plane",
+    "country": "Tanzania",
+    "country-code": "TZA",
+    "code": "JRO",
+    "name": "Kilimadjaro"
+  },
+  {
+    "type": "plane",
+    "country": "Thailand",
+    "country-code": "THA",
+    "code": "BKK",
+    "name": "Bangkok"
+  },
+  {
+    "type": "plane",
+    "country": "Thailand",
+    "country-code": "THA",
+    "code": "CNX",
+    "name": "Chiang Mai"
+  },
+  {
+    "type": "plane",
+    "country": "Thailand",
+    "country-code": "THA",
+    "code": "HDY",
+    "name": "Hatyai (Hat Yai)"
+  },
+  {
+    "type": "plane",
+    "country": "Thailand",
+    "country-code": "THA",
+    "code": "PYX",
+    "name": "Pattaya"
+  },
+  {
+    "type": "plane",
+    "country": "Thailand",
+    "country-code": "THA",
+    "code": "HKT",
+    "name": "Phuket"
+  },
+  {
+    "type": "plane",
+    "country": "Thailand",
+    "country-code": "THA",
+    "code": "UTP",
+    "name": "Utapao (Pattaya)"
+  },
+  {
+    "type": "plane",
+    "country": "Togo",
+    "country-code": "TGO",
+    "code": "LFW",
+    "name": "Lome"
+  },
+  {
+    "type": "plane",
+    "country": "Tonga",
+    "country-code": "TON",
+    "code": "TBU",
+    "name": "Nuku'alofa-Fua'Amotu Int"
+  },
+  {
+    "type": "plane",
+    "country": "Trinidad And Tobago",
+    "country-code": "TTO",
+    "code": "POS",
+    "name": "Port of Spain"
+  },
+  {
+    "type": "plane",
+    "country": "Trinidad And Tobago",
+    "country-code": "TTO",
+    "code": "TAB",
+    "name": "Tobago"
+  },
+  {
+    "type": "plane",
+    "country": "Tunisia",
+    "country-code": "TUN",
+    "code": "DJE",
+    "name": "Djerba"
+  },
+  {
+    "type": "plane",
+    "country": "Tunisia",
+    "country-code": "TUN",
+    "code": "MIR",
+    "name": "Monastir"
+  },
+  {
+    "type": "plane",
+    "country": "Tunisia",
+    "country-code": "TUN",
+    "code": "SFA",
+    "name": "Sfax"
+  },
+  {
+    "type": "plane",
+    "country": "Tunisia",
+    "country-code": "TUN",
+    "code": "TUN",
+    "name": "Tunis - Carthage"
+  },
+  {
+    "type": "plane",
+    "country": "Turkey",
+    "country-code": "TUR",
+    "code": "ADA",
+    "name": "Adana"
+  },
+  {
+    "type": "plane",
+    "country": "Turkey",
+    "country-code": "TUR",
+    "code": "ANK",
+    "name": "Ankara"
+  },
+  {
+    "type": "plane",
+    "country": "Turkey",
+    "country-code": "TUR",
+    "code": "AYT",
+    "name": "Antalya"
+  },
+  {
+    "type": "plane",
+    "country": "Turkey",
+    "country-code": "TUR",
+    "code": "DLM",
+    "name": "Dalaman"
+  },
+  {
+    "type": "plane",
+    "country": "Turkey",
+    "country-code": "TUR",
+    "code": "IST",
+    "name": "Istanbul - Ataturk"
+  },
+  {
+    "type": "plane",
+    "country": "Turkey",
+    "country-code": "TUR",
+    "code": "SAW",
+    "name": "Istanbul - Sabiha Gokcen"
+  },
+  {
+    "type": "plane",
+    "country": "Turkey",
+    "country-code": "TUR",
+    "code": "IZM",
+    "name": "Izmir"
+  },
+  {
+    "type": "plane",
+    "country": "Uganda",
+    "country-code": "UGA",
+    "code": "EBB",
+    "name": "Entebbe"
+  },
+  {
+    "type": "plane",
+    "country": "Uganda",
+    "country-code": "UGA",
+    "code": "ULU",
+    "name": "Gulu"
+  },
+  {
+    "type": "plane",
+    "country": "Ukraine",
+    "country-code": "UKR",
+    "code": "KBP",
+    "name": "Kiev - Borispol"
+  },
+  {
+    "type": "plane",
+    "country": "Ukraine",
+    "country-code": "UKR",
+    "code": "IEV",
+    "name": "Kiev - Zhulhany"
+  },
+  {
+    "type": "plane",
+    "country": "Ukraine",
+    "country-code": "UKR",
+    "code": "LWO",
+    "name": "Lvov (Lwow, Lemberg)"
+  },
+  {
+    "type": "plane",
+    "country": "Ukraine",
+    "country-code": "UKR",
+    "code": "ODS",
+    "name": "Odessa"
+  },
+  {
+    "type": "plane",
+    "country": "Ukraine",
+    "country-code": "UKR",
+    "code": "SIP",
+    "name": "Simferopol"
+  },
+  {
+    "type": "plane",
+    "country": "United Arab Emirates",
+    "country-code": "ARE",
+    "code": "AUH",
+    "name": "Abu Dhabi"
+  },
+  {
+    "type": "plane",
+    "country": "United Arab Emirates",
+    "country-code": "ARE",
+    "code": "FJR",
+    "name": "Alfujairah (Fujairah)"
+  },
+  {
+    "type": "plane",
+    "country": "United Arab Emirates",
+    "country-code": "ARE",
+    "code": "DXB",
+    "name": "Dubai"
+  },
+  {
+    "type": "plane",
+    "country": "United Arab Emirates",
+    "country-code": "ARE",
+    "code": "RKT",
+    "name": "Ras al Khaymah (Khaimah)"
+  },
+  {
+    "type": "plane",
+    "country": "United Arab Emirates",
+    "country-code": "ARE",
+    "code": "SHJ",
+    "name": "Sharjah"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "ABZ",
+    "name": "Aberdeen"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "BHD",
+    "name": "Belfast - Harbour"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "BFS",
+    "name": "Belfast International"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "BHX",
+    "name": "Birmingham"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "BRS",
+    "name": "Bristol"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "CBG",
+    "name": "Cambridge"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "CWL",
+    "name": "Cardiff"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "EMA",
+    "name": "Derby (East Midlands)"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "LDY",
+    "name": "Derry (Londonderry)"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "EDI",
+    "name": "Edinburgh"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "GLA",
+    "name": "Glasgow"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "PIK",
+    "name": "Glasgow, Prestwick"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "GCI",
+    "name": "Guernsey"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "HUY",
+    "name": "Humberside"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "INV",
+    "name": "Inverness"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "IOM",
+    "name": "Isle of Man"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "JER",
+    "name": "Jersey"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "LBA",
+    "name": "Leeds/Bradford"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "LPL",
+    "name": "Liverpool"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "LCY",
+    "name": "London - City Airport"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "LGW",
+    "name": "London - Gatwick"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "LHR",
+    "name": "London - Heathrow"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "LTN",
+    "name": "London - Luton"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "STN",
+    "name": "London - Stansted"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "MAN",
+    "name": "Manchester"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "NCL",
+    "name": "Newcastle"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "KOI",
+    "name": "Orkney"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "SOU",
+    "name": "Southampton - Eastleigh"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "SEN",
+    "name": "Southend"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "SYY",
+    "name": "Stornway"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "LSI",
+    "name": "Sumburgh (Shetland)"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "MME",
+    "name": "Tees Side"
+  },
+  {
+    "type": "plane",
+    "country": "United Kingdom",
+    "country-code": "GBR",
+    "code": "WIC",
+    "name": "Wick"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ABR",
+    "name": "Aberdeen, SD"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ABI",
+    "name": "Abilene, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CAK",
+    "name": "Akron, OH"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ABY",
+    "name": "Albany, GA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ALB",
+    "name": "Albany, NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ABQ",
+    "name": "Albuquerque, NM"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ESF",
+    "name": "Alexandria, La"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ABE",
+    "name": "Allentown, PA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "AOO",
+    "name": "Altoona, PA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "AMA",
+    "name": "Amarillo, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ANC",
+    "name": "Anchorage, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ARB",
+    "name": "Ann Arbor, MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ANB",
+    "name": "Anniston, AL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ATW",
+    "name": "Appelton/Neenah/MenashaWI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "AVL",
+    "name": "Asheville, NC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ASE",
+    "name": "Aspen Snowmass, CO"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "AHN",
+    "name": "Athens, GA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ATO",
+    "name": "Athens, OH"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ATL",
+    "name": "Atlanta, Hartsfield"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ACY",
+    "name": "Atlantic City, NJ"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "AGS",
+    "name": "Augusta, GA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "AUG",
+    "name": "Augusta, ME"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BFL",
+    "name": "Bakersfield, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BWI",
+    "name": "Baltimore Washington"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BGR",
+    "name": "Bangor, ME"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BTR",
+    "name": "Baton Rouge, La"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BPT",
+    "name": "Beaumont/Pt. Arthur, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BKW",
+    "name": "Beckley, WV"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BLI",
+    "name": "Bellingham, WA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BJI",
+    "name": "Bemidji, MN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BEH",
+    "name": "Benton Harbour, MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BET",
+    "name": "Bethel, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BIL",
+    "name": "Billings, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BHM",
+    "name": "Birmingham, AL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BIS",
+    "name": "Bismarck/Mandan, ND"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BMI",
+    "name": "Bloomington, IL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BMG",
+    "name": "Bloomington, IN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BLF",
+    "name": "Bluefield, WV"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BOI",
+    "name": "Boise, ID"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BXS",
+    "name": "Borrego Springs, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BOS",
+    "name": "Boston - Logan, MA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BZN",
+    "name": "Bozeman, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BFD",
+    "name": "Bradford/Warren, Olean NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BRD",
+    "name": "Brainerd, MN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BDR",
+    "name": "Bridgeport, CT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BKX",
+    "name": "Brookings, SD"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BQK",
+    "name": "Brunswick, GA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BUF",
+    "name": "Buffalo/Niagara Falls, NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BHC",
+    "name": "Bullhead City, NV"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BUR",
+    "name": "Burbank, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BRL",
+    "name": "Burlington, IA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BTV",
+    "name": "Burlington, VT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BTM",
+    "name": "Butte, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CLD",
+    "name": "Carlsbad, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CPR",
+    "name": "Casper, WY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CDC",
+    "name": "Cedar City, UT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CID",
+    "name": "Cedar Rapids, IA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CMI",
+    "name": "Champaign, IL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CHS",
+    "name": "Charleston, SC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CRW",
+    "name": "Charleston, WV"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CLT",
+    "name": "Charlotte, NC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CHO",
+    "name": "Charlottesville, VA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CHA",
+    "name": "Chattanooga, TN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ORD",
+    "name": "Chicago O'Hare Intl"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CHI",
+    "name": "Chicago, IL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MDW",
+    "name": "Chicago, Midway, IL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CIC",
+    "name": "Chico, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CVG",
+    "name": "Cincinnati, OH"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CKB",
+    "name": "Clarksburg, WV"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CLE",
+    "name": "Cleveland, Hopkins, OH"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BKL",
+    "name": "Cleveland,BurkeLakefront"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "COD",
+    "name": "Cody/Powell/Yellowstone"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "KCC",
+    "name": "Coffmann Cove, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CLL",
+    "name": "College Station/Bryan, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "COS",
+    "name": "Colorado Springs, CO"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CAE",
+    "name": "Columbia, SC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CSG",
+    "name": "Columbus, GA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CMH",
+    "name": "Columbus, OH"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CCR",
+    "name": "Concord, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CDV",
+    "name": "Cordova, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CRP",
+    "name": "Corpus Christi, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CGA",
+    "name": "Craig, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CEC",
+    "name": "Crescent City, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DAL",
+    "name": "Dallas, Love Field, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DFW",
+    "name": "Dallas/Ft. Worth, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DAN",
+    "name": "Danville, VA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DAY",
+    "name": "Dayton, OH"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DAB",
+    "name": "Daytona Beach, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DEC",
+    "name": "Decatur, IL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DEN",
+    "name": "Denver International"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DSM",
+    "name": "Des Moines, IA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DET",
+    "name": "Detroit City Airport, MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DTW",
+    "name": "Detroit Metropolitan"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DTT",
+    "name": "Detroit, MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DVL",
+    "name": "Devils Lake, ND"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DLG",
+    "name": "Dillingham, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DHN",
+    "name": "Dothan, AL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DUJ",
+    "name": "Dubois, PA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DBQ",
+    "name": "Dubuque, IA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DLH",
+    "name": "Duluth, MN/Superior, WI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DRO",
+    "name": "Durango, CO"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DUT",
+    "name": "Dutch Harbor, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "EAU",
+    "name": "Eau Clarie, WI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ELP",
+    "name": "El Paso, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "EKI",
+    "name": "Elkhart, IN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "EKO",
+    "name": "Elko, NV"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ELM",
+    "name": "Elmira, NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ELY",
+    "name": "Ely, NV"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ERI",
+    "name": "Erie, PA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ESC",
+    "name": "Escabana, MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "EUG",
+    "name": "Eugene, OR"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ACV",
+    "name": "Eureka, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "EVV",
+    "name": "Evansville, IN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FAI",
+    "name": "Fairbanks, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FAR",
+    "name": "Fargo, ND, MN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FMN",
+    "name": "Farmington, NM"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FYV",
+    "name": "Fayetteville, AR"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FAY",
+    "name": "Fayetteville/Ft. Bragg,NC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FLG",
+    "name": "Flagstaff, AZ"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FNT",
+    "name": "Flint, MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FLO",
+    "name": "Florence, SC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FOD",
+    "name": "Fort Dodge, IA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FHU",
+    "name": "Fort Huachuca/SierraVista"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FLL",
+    "name": "Fort Lauderdale/Hollywood"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FMY",
+    "name": "Fort Myers, Metropolitan"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "RSW",
+    "name": "Fort Myers, SW Florida"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FSM",
+    "name": "Fort Smith, AR"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "VPS",
+    "name": "Fort Walton Beach, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FWA",
+    "name": "Fort Wayne, IN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FKL",
+    "name": "Franklin/Oil City, PA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FAT",
+    "name": "Fresno, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GAD",
+    "name": "Gadsden, AL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GNV",
+    "name": "Gainesville, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GCC",
+    "name": "Gilette, WY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GGW",
+    "name": "Glasgow, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GDV",
+    "name": "Glendive, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GCN",
+    "name": "Grand Canyon, AZ"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GFK",
+    "name": "Grand Forks, ND"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GJT",
+    "name": "Grand Junction, CO"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GRR",
+    "name": "Grand Rapids, MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GPZ",
+    "name": "Grand Rapids, MN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GTF",
+    "name": "Great Falls, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GRB",
+    "name": "Green Bay, WI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LWB",
+    "name": "Greenbrier/Lewisburg, WV"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GSO",
+    "name": "Greensboro/Winston Salem"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GLH",
+    "name": "Greenville, MS"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PGV",
+    "name": "Greenville, NC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GSP",
+    "name": "Greenville/Spartanburg SC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GON",
+    "name": "Groton/New London, CT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GPT",
+    "name": "Gulfport/Biloxi, MS"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GUC",
+    "name": "Gunnison/Crested Butte CO"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HNS",
+    "name": "Haines, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CMX",
+    "name": "Hancock, MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HRL",
+    "name": "Harlington/S.Padre Island"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HAR",
+    "name": "Harrisburg, PA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MDT",
+    "name": "Harrisburg, PA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BDL",
+    "name": "Hartford / Springfield MA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HVR",
+    "name": "Havre, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HLN",
+    "name": "Helena, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HIB",
+    "name": "Hibbing, MN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HKY",
+    "name": "Hickory, NC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ITO",
+    "name": "Hilo, HI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HHH",
+    "name": "Hilton Head Island, SC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HOM",
+    "name": "Homer, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HNL",
+    "name": "Honolulu, HI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HNH",
+    "name": "Hoonah, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HOU",
+    "name": "Houston, Hobby, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "IAH",
+    "name": "Houston, Intercontinental"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HTS",
+    "name": "Huntington, OH"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HSV",
+    "name": "Huntsville, AL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HON",
+    "name": "Huron, SD"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HYA",
+    "name": "Hyannis, MA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HYG",
+    "name": "Hydaburg, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "IDA",
+    "name": "Idaho Falls, ID"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ILI",
+    "name": "Iliamna, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "IPL",
+    "name": "Imperial, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "IND",
+    "name": "Indianapolis, IN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "INL",
+    "name": "International Falls, MN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "IYK",
+    "name": "Inykern, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ITH",
+    "name": "Ithaca/Cortland, NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "JAC",
+    "name": "Jackson Hole, WY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "JXN",
+    "name": "Jackson, MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "JAN",
+    "name": "Jackson, MS"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MKL",
+    "name": "Jackson, TN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "JAX",
+    "name": "Jacksonville, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "OAJ",
+    "name": "Jacksonville, NC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "JMS",
+    "name": "Jamestown, ND"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "JHW",
+    "name": "Jamestown, NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "JST",
+    "name": "Johnstown, PA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "JLN",
+    "name": "Joplin, MO"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "JNU",
+    "name": "Juneau, AK - Juneau Intl"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "OGG",
+    "name": "Kahului, HI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "AZO",
+    "name": "Kalamazoo/Battle Creek MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FCA",
+    "name": "Kalispell, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MCI",
+    "name": "Kansas City, MO - Intl"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "JHM",
+    "name": "Kapalua West, HI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MKK",
+    "name": "Kaunakakai, HI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ENA",
+    "name": "Kenai, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "KTN",
+    "name": "Ketchikan, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "EYW",
+    "name": "Key West, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ILE",
+    "name": "Killeem, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "AKN",
+    "name": "King Salomon, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ISO",
+    "name": "Kingston, NC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LMT",
+    "name": "Klamath Fall, OR"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "KLW",
+    "name": "Klawock, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TYS",
+    "name": "Knoxville, TN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ADQ",
+    "name": "Kodiak, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "KOA",
+    "name": "Kona, HI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "OTZ",
+    "name": "Kotzbue, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LSE",
+    "name": "La Crosse, WI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "WLB",
+    "name": "Labouchere Bay, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LAF",
+    "name": "Lafayette, IN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LFT",
+    "name": "Lafayette, La"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LCH",
+    "name": "Lake Charles, La"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HII",
+    "name": "Lake Havasu City, AZ"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TVL",
+    "name": "Lake Tahoe, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LNY",
+    "name": "Lanai City, HI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LNS",
+    "name": "Lancaster, PA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LAN",
+    "name": "Lansing, MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LAR",
+    "name": "Laramie, WY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LRD",
+    "name": "Laredo, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LAS",
+    "name": "Las Vegas, NV"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LBE",
+    "name": "Latrobe, PA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PIB",
+    "name": "Laurel/Hattisburg, MS"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LAW",
+    "name": "Lawton, OK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LEB",
+    "name": "Lebanon, NH"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LWS",
+    "name": "Lewiston, ID"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LWT",
+    "name": "Lewistown, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LEX",
+    "name": "Lexington, KY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LIH",
+    "name": "Lihue, HI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LNK",
+    "name": "Lincoln, NE"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LIT",
+    "name": "Little Rock, AR"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LGB",
+    "name": "Long Beach, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LIJ",
+    "name": "Long Island, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ISP",
+    "name": "Long Island, MacArthur"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GGG",
+    "name": "Longview/Kilgore, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LAX",
+    "name": "Los Angeles, CA - Intl"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SDF",
+    "name": "Louisville, KY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LBB",
+    "name": "Lubbock, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LYH",
+    "name": "Lynchburg, VA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MCN",
+    "name": "Macon, GA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MSN",
+    "name": "Madison, WI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MHT",
+    "name": "Manchester, NH"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MTH",
+    "name": "Marathon, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MQT",
+    "name": "Marquette, MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MVY",
+    "name": "Martha's Vineyard, MA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MCW",
+    "name": "Mason City, IA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MTO",
+    "name": "Mattoon, IL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MFE",
+    "name": "McAllen, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MFR",
+    "name": "Medford, OR"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MLB",
+    "name": "Melbourne, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MEM",
+    "name": "Memphis, TN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MCE",
+    "name": "Merced, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MEI",
+    "name": "Meridian, MS"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MTM",
+    "name": "Metlakatla, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MIA",
+    "name": "Miami, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MAF",
+    "name": "Midland/Odessa, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MLS",
+    "name": "Miles City, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MKE",
+    "name": "Milwaukee, WI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MSP",
+    "name": "Minneapolis - St. Paul"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MOT",
+    "name": "Minot, ND"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MSO",
+    "name": "Missula, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MHE",
+    "name": "Mitchell, SD"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MOB",
+    "name": "Mobile, AL - Pascagoula"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MOD",
+    "name": "Modesto, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MLI",
+    "name": "Moline/Quad Cities, IL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MLU",
+    "name": "Monroe, La"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MRY",
+    "name": "Monterey, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MGM",
+    "name": "Montgomery, AL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MTJ",
+    "name": "Montrose/Tellruide, CO"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MGW",
+    "name": "Morgantown, WV"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MWH",
+    "name": "Moses Lake, WA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MCL",
+    "name": "Mt. McKinley, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MSL",
+    "name": "Muscle Shoals, AL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MKG",
+    "name": "Muskegon, MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MYR",
+    "name": "Myrtle Beach, SC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ACK",
+    "name": "Nantucket, MA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "APF",
+    "name": "Naples, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "BNA",
+    "name": "Nashville, TN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "EWN",
+    "name": "New Bern, NC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HVN",
+    "name": "New Haven, CT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MSY",
+    "name": "New Orleans, La"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "LGA",
+    "name": "New York - La Guardia, NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "EWR",
+    "name": "New York - Newark, NJ"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "NYC",
+    "name": "New York, NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "JFK",
+    "name": "New York-J.F.Kennedy NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SWF",
+    "name": "Newburgh, NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PHF",
+    "name": "Newport News/Williamsburg"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "OME",
+    "name": "Nome, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ORF",
+    "name": "Norfolk/Virginia Beach"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "OTH",
+    "name": "North Bend, OR"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "OAK",
+    "name": "Oakland, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "OKC",
+    "name": "Oklahoma City, Will Roger"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "OMA",
+    "name": "Omaha, NE"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ONT",
+    "name": "Ontario, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SNA",
+    "name": "Orange County-Santa Ana"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MCO",
+    "name": "Orlando International Airport"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SFB",
+    "name": "Orlando Sanford International Airport"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "OSH",
+    "name": "Oshkosh, WI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "OWB",
+    "name": "Owensboro, KY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "OXR",
+    "name": "Oxnard, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PAH",
+    "name": "Paducah, KY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PGA",
+    "name": "Page/Lake Powell, AZ"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PKB",
+    "name": "Pakersburg, WV/Marietta"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PSP",
+    "name": "Palm Springs, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PMD",
+    "name": "Palmdale/Lancaster, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PFN",
+    "name": "Panama City, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PSC",
+    "name": "Pasco, WA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PLN",
+    "name": "Pellston, MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PDT",
+    "name": "Pendelton, OR"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PNS",
+    "name": "Pensacola, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PIA",
+    "name": "Peoria/Bloomington, IL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PSG",
+    "name": "Petersburg, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PHL",
+    "name": "Philadelphia, PA - Intl"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PHX",
+    "name": "Phoenix -Sky Harbor Intl"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PIR",
+    "name": "Pierre, SD"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PIT",
+    "name": "Pittsburgh Intl Airport"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PLB",
+    "name": "Plattsburgh, NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PIH",
+    "name": "Pocatello, ID"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CLM",
+    "name": "Port Angeles, WA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PDX",
+    "name": "Portland Intl, OR"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PWM",
+    "name": "Portland, ME"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "POU",
+    "name": "Poughkeepsie, NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PQI",
+    "name": "Presque Island, ME"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PVD",
+    "name": "Providence, RI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SCC",
+    "name": "Prudhoe Bay, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PUB",
+    "name": "Pueblo, CO"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PUW",
+    "name": "Pullman, WA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "UIN",
+    "name": "Quincy, IL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "RDU",
+    "name": "Raleigh/Durham, NC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "RAP",
+    "name": "Rapid City, SD"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "RDG",
+    "name": "Reading, PA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "RDD",
+    "name": "Redding, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "RDM",
+    "name": "Redmond, OR"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "RNO",
+    "name": "Reno, NV"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "RHI",
+    "name": "Rhinelander, WI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "RIC",
+    "name": "Richmond, VA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ROA",
+    "name": "Roanoke, VA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "RST",
+    "name": "Rochester, MN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ROC",
+    "name": "Rochester, NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "RKS",
+    "name": "Rock Springs, WY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "RFD",
+    "name": "Rockford, IL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "RKD",
+    "name": "Rockland, ME"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "RWI",
+    "name": "Rocky Mount - Wilson, NC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SMF",
+    "name": "Sacramento, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "MBS",
+    "name": "Saginaw/Bay City/Midland"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SLE",
+    "name": "Salem, OR"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SNS",
+    "name": "Salinas, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SBY",
+    "name": "Salisbury, MD"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SLC",
+    "name": "Salt Lake City, UT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SJT",
+    "name": "San Angelo, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SAT",
+    "name": "San Antonio, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SAN",
+    "name": "San Diego-Lindberg Field"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SFO",
+    "name": "San Francisco - Intl"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SJC",
+    "name": "San Jose, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SBP",
+    "name": "San Luis Obisco, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SBA",
+    "name": "Santa Barbara, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SMX",
+    "name": "Santa Maria, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "STS",
+    "name": "Santa Rosa, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SRQ",
+    "name": "Sarasota/Bradenton, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SAV",
+    "name": "Savannah, GA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SCF",
+    "name": "Scottsdale, AZ"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SEA",
+    "name": "Seattle/Tacoma, WA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SHD",
+    "name": "Shenandoah Valley/Stauton"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SHR",
+    "name": "Sheridan, WY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SHV",
+    "name": "Shreveport, La"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SDY",
+    "name": "Sidney, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SUX",
+    "name": "Sioux City, IA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "FSD",
+    "name": "Sioux Falls, SD"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SIT",
+    "name": "Sitka, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SGY",
+    "name": "Skagway, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SBN",
+    "name": "South Bend, IN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "GEG",
+    "name": "Spokane, WA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SPI",
+    "name": "Springfield, IL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SGF",
+    "name": "Springfield, MO"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "STX",
+    "name": "St. Croix"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SGU",
+    "name": "St. George, UT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "STL",
+    "name": "St. Louis - Lambert, MO"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "STT",
+    "name": "St. Thomas"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SCE",
+    "name": "State College/Belefonte"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HDN",
+    "name": "Steamboat Springs, CO"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SCK",
+    "name": "Stockton, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SUN",
+    "name": "Sun Valley, ID"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TKA",
+    "name": "Talkeetna, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TLH",
+    "name": "Tallahassee, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TPA",
+    "name": "Tampa Intl, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TEX",
+    "name": "Telluride, CO"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HUF",
+    "name": "Terre Haute, IN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TXK",
+    "name": "Texarkana, AR"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TVF",
+    "name": "Thief River Falls, MN"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "KTB",
+    "name": "Thorne Bay, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TOL",
+    "name": "Toledo, OH"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TVC",
+    "name": "Traverse City, MI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TTN",
+    "name": "Trenton/Princeton, NJ"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TRI",
+    "name": "Tri-Cities Regional,TN/VA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TUS",
+    "name": "Tucson, AZ"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TUP",
+    "name": "Tulepo, MS"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TUL",
+    "name": "Tulsa, OK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TCL",
+    "name": "Tuscaloosa, AL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TWF",
+    "name": "Twin Falls, ID"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "TYR",
+    "name": "Tyler, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "UCA",
+    "name": "Utica, NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "EGE",
+    "name": "Vail, CO"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "VDZ",
+    "name": "Valdez, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "VLD",
+    "name": "Valdosta, GA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "VEL",
+    "name": "Vernal, UT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "VRB",
+    "name": "Vero Beach/Ft. Pierce, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "VIS",
+    "name": "Visalia, CA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ACT",
+    "name": "Waco, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ALW",
+    "name": "Walla Walla, WA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "IAD",
+    "name": "Washington DC-Dulles Int"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "DCA",
+    "name": "Washington DC-R. Reagan"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "WAS",
+    "name": "Washington, DC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ALO",
+    "name": "Waterloo, IA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ATY",
+    "name": "Watertown, SD"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "CWA",
+    "name": "Wausau/Stevens Point, WI"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "EAT",
+    "name": "Wenatchee, WA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "PBI",
+    "name": "West Palm Beach, FL"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "WYS",
+    "name": "West Yellowstone, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "HPN",
+    "name": "White Plains, NY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "SPS",
+    "name": "Wichita Falls, TX"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ICT",
+    "name": "Wichita, KS"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "AVP",
+    "name": "Wilkes Barre/Scranton, PA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "IPT",
+    "name": "Williamsport, PA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ISL",
+    "name": "Williston, ND"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ILM",
+    "name": "Wilmington, NC"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "OLF",
+    "name": "Wolf Point, MT"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "ORH",
+    "name": "Worcester, MA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "WRL",
+    "name": "Worland, WY"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "WRG",
+    "name": "Wrangell, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "YKM",
+    "name": "Yakima, WA"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "YAK",
+    "name": "Yakutat, AK"
+  },
+  {
+    "type": "plane",
+    "country": "United States",
+    "country-code": "USA",
+    "code": "YUM",
+    "name": "Yuma, AZ"
+  },
+  {
+    "type": "plane",
+    "country": "Uruguay",
+    "country-code": "URY",
+    "code": "MVD",
+    "name": "Montevideo - Carrasco"
+  },
+  {
+    "type": "plane",
+    "country": "Uzbekistan",
+    "country-code": "UZB",
+    "code": "SKD",
+    "name": "Samarkand"
+  },
+  {
+    "type": "plane",
+    "country": "Uzbekistan",
+    "country-code": "UZB",
+    "code": "TAS",
+    "name": "Tashkent - Vostochny"
+  },
+  {
+    "type": "plane",
+    "country": "Uzbekistan",
+    "country-code": "UZB",
+    "code": "TMZ",
+    "name": "Termez (Termes)"
+  },
+  {
+    "type": "plane",
+    "country": "Vanuatu",
+    "country-code": "VUT",
+    "code": "VLI",
+    "name": "Port Vila"
+  },
+  {
+    "type": "plane",
+    "country": "Vanuatu",
+    "country-code": "VUT",
+    "code": "SON",
+    "name": "Santo"
+  },
+  {
+    "type": "plane",
+    "country": "Venezuela",
+    "country-code": "VEN",
+    "code": "BLA",
+    "name": "Barcelona - Venezuela"
+  },
+  {
+    "type": "plane",
+    "country": "Venezuela",
+    "country-code": "VEN",
+    "code": "CCS",
+    "name": "Caracas"
+  },
+  {
+    "type": "plane",
+    "country": "Venezuela",
+    "country-code": "VEN",
+    "code": "MAR",
+    "name": "Maracaibo - La Chinita"
+  },
+  {
+    "type": "plane",
+    "country": "Venezuela",
+    "country-code": "VEN",
+    "code": "PMV",
+    "name": "Margerita"
+  },
+  {
+    "type": "plane",
+    "country": "Venezuela",
+    "country-code": "VEN",
+    "code": "PZO",
+    "name": "Puerto Ordaz"
+  },
+  {
+    "type": "plane",
+    "country": "Venezuela",
+    "country-code": "VEN",
+    "code": "VLN",
+    "name": "Valencia"
+  },
+  {
+    "type": "plane",
+    "country": "Vietnam",
+    "country-code": "VNM",
+    "code": "HAN",
+    "name": "Hanoi - Noibai"
+  },
+  {
+    "type": "plane",
+    "country": "Vietnam",
+    "country-code": "VNM",
+    "code": "HUI",
+    "name": "Hue - Phu Bai"
+  },
+  {
+    "type": "plane",
+    "country": "Vietnam",
+    "country-code": "VNM",
+    "code": "SGN",
+    "name": "Saigon (Ho Chi Minh City)"
+  },
+  {
+    "type": "plane",
+    "country": "Virgin Islands, British",
+    "country-code": "VGB",
+    "code": "EIS 2",
+    "name": "Beef Island"
+  },
+  {
+    "type": "plane",
+    "country": "Virgin Islands, British",
+    "country-code": "VGB",
+    "code": "EIS 1",
+    "name": "Tortola"
+  },
+  {
+    "type": "plane",
+    "country": "Virgin Islands, British",
+    "country-code": "VGB",
+    "code": "VIJ",
+    "name": "Virgin Gorda"
+  },
+  {
+    "type": "plane",
+    "country": "Wallis and Futuna Islands",
+    "country-code": "WLF",
+    "code": "FUT",
+    "name": "Futuna"
+  },
+  {
+    "type": "plane",
+    "country": "Wallis and Futuna Islands",
+    "country-code": "WLF",
+    "code": "WLS",
+    "name": "Wallis"
+  },
+  {
+    "type": "plane",
+    "country": "Yemen",
+    "country-code": "YEM",
+    "code": "ADE",
+    "name": "Aden"
+  },
+  {
+    "type": "plane",
+    "country": "Yemen",
+    "country-code": "YEM",
+    "code": "SAH",
+    "name": "Sanaa (Sana'a)-Sana'a Int"
+  },
+  {
+    "type": "plane",
+    "country": "Zambia",
+    "country-code": "ZMB",
+    "code": "CIP",
+    "name": "Chipata"
+  },
+  {
+    "type": "plane",
+    "country": "Zambia",
+    "country-code": "ZMB",
+    "code": "KIW",
+    "name": "Kitwe"
+  },
+  {
+    "type": "plane",
+    "country": "Zambia",
+    "country-code": "ZMB",
+    "code": "LUN",
+    "name": "Lusaka"
+  },
+  {
+    "type": "plane",
+    "country": "Zambia",
+    "country-code": "ZMB",
+    "code": "MFU",
+    "name": "Mfuwe"
+  },
+  {
+    "type": "plane",
+    "country": "Zambia",
+    "country-code": "ZMB",
+    "code": "NLA",
+    "name": "N'Dola"
+  },
+  {
+    "type": "plane",
+    "country": "Zimbabwe",
+    "country-code": "ZWE",
+    "code": "BFO",
+    "name": "Buffalo Range"
+  },
+  {
+    "type": "plane",
+    "country": "Zimbabwe",
+    "country-code": "ZWE",
+    "code": "BUQ",
+    "name": "Bulawayo"
+  },
+  {
+    "type": "plane",
+    "country": "Zimbabwe",
+    "country-code": "ZWE",
+    "code": "FRW",
+    "name": "Francistown"
+  },
+  {
+    "type": "plane",
+    "country": "Zimbabwe",
+    "country-code": "ZWE",
+    "code": "GWE",
+    "name": "Gweru"
+  },
+  {
+    "type": "plane",
+    "country": "Zimbabwe",
+    "country-code": "ZWE",
+    "code": "HRE",
+    "name": "Harare"
+  },
+  {
+    "type": "plane",
+    "country": "Zimbabwe",
+    "country-code": "ZWE",
+    "code": "HWN",
+    "name": "Hwange National Park"
+  },
+  {
+    "type": "plane",
+    "country": "Zimbabwe",
+    "country-code": "ZWE",
+    "code": "MVZ",
+    "name": "Masvingo"
+  },
+  {
+    "type": "plane",
+    "country": "Zimbabwe",
+    "country-code": "ZWE",
+    "code": "SAY",
+    "name": "Salisbury"
+  },
+  {
+    "type": "plane",
+    "country": "Zimbabwe",
+    "country-code": "ZWE",
+    "code": "VFA",
+    "name": "Victoria Falls"
+  }
+]

--- a/data/nationalities.json
+++ b/data/nationalities.json
@@ -1,0 +1,850 @@
+[
+  {
+    "name": "Afghanistan",
+    "code": "AFG"
+  },
+  {
+    "name": "Albania",
+    "code": "ALB"
+  },
+  {
+    "name": "Algeria",
+    "code": "DZA"
+  },
+  {
+    "name": "Andorra",
+    "code": "AND"
+  },
+  {
+    "name": "Angola",
+    "code": "AGO"
+  },
+  {
+    "name": "Anguilla",
+    "code": "AIA"
+  },
+  {
+    "name": "Antigua and Barbuda",
+    "code": "ATG"
+  },
+  {
+    "name": "Argentina",
+    "code": "ARG"
+  },
+  {
+    "name": "Armenia",
+    "code": "ARM"
+  },
+  {
+    "name": "Australia",
+    "code": "AUS"
+  },
+  {
+    "name": "Austria",
+    "code": "AUT"
+  },
+  {
+    "name": "Azerbaijan",
+    "code": "AZE"
+  },
+  {
+    "name": "Bahamas",
+    "code": "BHS"
+  },
+  {
+    "name": "Bahrain",
+    "code": "BHR"
+  },
+  {
+    "name": "Bangladesh",
+    "code": "BGD"
+  },
+  {
+    "name": "Barbados",
+    "code": "BRB"
+  },
+  {
+    "name": "Belarus",
+    "code": "BLR"
+  },
+  {
+    "name": "Belgium",
+    "code": "BEL"
+  },
+  {
+    "name": "Belize",
+    "code": "BLZ"
+  },
+  {
+    "name": "Benin",
+    "code": "BEN"
+  },
+  {
+    "name": "Bermuda",
+    "code": "BMU"
+  },
+  {
+    "name": "Bhutan",
+    "code": "BTN"
+  },
+  {
+    "name": "Bolivia",
+    "code": "BOL"
+  },
+  {
+    "name": "Bosnia and Herzegovina",
+    "code": "BIH"
+  },
+  {
+    "name": "Botswana",
+    "code": "BWA"
+  },
+  {
+    "name": "Brazil",
+    "code": "BRA"
+  },
+  {
+    "name": "British Virgin Islands",
+    "code": "VGB"
+  },
+  {
+    "name": "Brunei",
+    "code": "BRN"
+  },
+  {
+    "name": "Bulgaria",
+    "code": "BGR"
+  },
+  {
+    "name": "Burkina",
+    "code": "BFA"
+  },
+  {
+    "name": "Burma (Myanmar)",
+    "code": "BUR"
+  },
+  {
+    "name": "Burundi",
+    "code": "BDI"
+  },
+  {
+    "name": "Cambodia",
+    "code": "KHM"
+  },
+  {
+    "name": "Cameroon",
+    "code": "CMR"
+  },
+  {
+    "name": "Canada",
+    "code": "CAN"
+  },
+  {
+    "name": "Cape Verde",
+    "code": "CPV"
+  },
+  {
+    "name": "Cayman Islands",
+    "code": "CYM"
+  },
+  {
+    "name": "Central African Republic",
+    "code": "CAF"
+  },
+  {
+    "name": "Chad",
+    "code": "TCD"
+  },
+  {
+    "name": "Chile",
+    "code": "CHL"
+  },
+  {
+    "name": "China",
+    "code": "CHN"
+  },
+  {
+    "name": "Colombia",
+    "code": "COL"
+  },
+  {
+    "name": "Comoros",
+    "code": "COM"
+  },
+  {
+    "name": "Congo",
+    "code": "COG"
+  },
+  {
+    "name": "Costa Rica",
+    "code": "CRI"
+  },
+  {
+    "name": "Croatia",
+    "code": "HRV"
+  },
+  {
+    "name": "Cuba",
+    "code": "CUB"
+  },
+  {
+    "name": "Cyprus",
+    "code": "CYP"
+  },
+  {
+    "name": "Czech Republic",
+    "code": "CZE"
+  },
+  {
+    "name": "Czechoslovakia",
+    "code": "CSK"
+  },
+  {
+    "name": "Democratic Republic Of Congo",
+    "code": "ZAR"
+  },
+  {
+    "name": "Denmark",
+    "code": "DNK"
+  },
+  {
+    "name": "Djibouti",
+    "code": "DJI"
+  },
+  {
+    "name": "Dominica",
+    "code": "DMA"
+  },
+  {
+    "name": "Dominican Republic",
+    "code": "DOM"
+  },
+  {
+    "name": "East Timor (Timor-Leste)",
+    "code": "TLS"
+  },
+  {
+    "name": "Ecuador",
+    "code": "ECU"
+  },
+  {
+    "name": "Egypt",
+    "code": "EGY"
+  },
+  {
+    "name": "El Salvador",
+    "code": "SLV"
+  },
+  {
+    "name": "Equatorial Guinea",
+    "code": "GNQ"
+  },
+  {
+    "name": "Eritrea",
+    "code": "ERI"
+  },
+  {
+    "name": "Estonia",
+    "code": "EST"
+  },
+  {
+    "name": "Ethiopia",
+    "code": "ETH"
+  },
+  {
+    "name": "Fiji",
+    "code": "FJI"
+  },
+  {
+    "name": "Finland",
+    "code": "FIN"
+  },
+  {
+    "name": "France",
+    "code": "FRA"
+  },
+  {
+    "name": "Gabon",
+    "code": "GAB"
+  },
+  {
+    "name": "Gambia",
+    "code": "GMB"
+  },
+  {
+    "name": "Georgia",
+    "code": "GEO"
+  },
+  {
+    "name": "Germany",
+    "code": "DEU"
+  },
+  {
+    "name": "Ghana",
+    "code": "GHA"
+  },
+  {
+    "name": "Gibraltar",
+    "code": "GIB"
+  },
+  {
+    "name": "Greece",
+    "code": "GRC"
+  },
+  {
+    "name": "Greenland",
+    "code": "GRL"
+  },
+  {
+    "name": "Grenada",
+    "code": "GRD"
+  },
+  {
+    "name": "Guatemala",
+    "code": "GTM"
+  },
+  {
+    "name": "Guinea",
+    "code": "GIN"
+  },
+  {
+    "name": "Guinea-Bissau",
+    "code": "GNB"
+  },
+  {
+    "name": "Guyana",
+    "code": "GUY"
+  },
+  {
+    "name": "Haiti",
+    "code": "HTI"
+  },
+  {
+    "name": "Honduras",
+    "code": "HND"
+  },
+  {
+    "name": "Hong KONG",
+    "code": "HKG"
+  },
+  {
+    "name": "Hungary",
+    "code": "HUN"
+  },
+  {
+    "name": "Iceland",
+    "code": "ISL"
+  },
+  {
+    "name": "India",
+    "code": "IND"
+  },
+  {
+    "name": "Indonesia",
+    "code": "IDN"
+  },
+  {
+    "name": "Iran",
+    "code": "IRN"
+  },
+  {
+    "name": "Iraq",
+    "code": "IRQ"
+  },
+  {
+    "name": "Ireland",
+    "code": "IRL"
+  },
+  {
+    "name": "Israel",
+    "code": "ISR"
+  },
+  {
+    "name": "Italy",
+    "code": "ITA"
+  },
+  {
+    "name": "Ivory COAST",
+    "code": "CIV"
+  },
+  {
+    "name": "Jamaica",
+    "code": "JAM"
+  },
+  {
+    "name": "Japan",
+    "code": "JPN"
+  },
+  {
+    "name": "Jordan",
+    "code": "JOR"
+  },
+  {
+    "name": "Kazakhstan",
+    "code": "KAZ"
+  },
+  {
+    "name": "Kenya",
+    "code": "KEN"
+  },
+  {
+    "name": "Kiribati",
+    "code": "KIR"
+  },
+  {
+    "name": "Korea (North)",
+    "code": "PRK"
+  },
+  {
+    "name": "Kosovo",
+    "code": "UNK"
+  },
+  {
+    "name": "Kuwait",
+    "code": "KWT"
+  },
+  {
+    "name": "Kyrgyzstan",
+    "code": "KGZ"
+  },
+  {
+    "name": "Laos",
+    "code": "LAO"
+  },
+  {
+    "name": "Latvia",
+    "code": "LVA"
+  },
+  {
+    "name": "Lebanon",
+    "code": "LBN"
+  },
+  {
+    "name": "Lesotho",
+    "code": "LSO"
+  },
+  {
+    "name": "Liberia",
+    "code": "LBR"
+  },
+  {
+    "name": "Libya",
+    "code": "LBY"
+  },
+  {
+    "name": "Liechtenstein",
+    "code": "LIE"
+  },
+  {
+    "name": "Lithuania",
+    "code": "LTU"
+  },
+  {
+    "name": "Luxembourg",
+    "code": "LUX"
+  },
+  {
+    "name": "Macedonia",
+    "code": "MKD"
+  },
+  {
+    "name": "Madagascar",
+    "code": "MDG"
+  },
+  {
+    "name": "Malawi",
+    "code": "MWI"
+  },
+  {
+    "name": "Malaysia",
+    "code": "MYS"
+  },
+  {
+    "name": "Maldives",
+    "code": "MDV"
+  },
+  {
+    "name": "Mali",
+    "code": "MLI"
+  },
+  {
+    "name": "Malta",
+    "code": "MLT"
+  },
+  {
+    "name": "Marshall Islands",
+    "code": "MHL"
+  },
+  {
+    "name": "Mauritania",
+    "code": "MRT"
+  },
+  {
+    "name": "Mauritius",
+    "code": "MUS"
+  },
+  {
+    "name": "Mexico",
+    "code": "MEX"
+  },
+  {
+    "name": "Micronesia",
+    "code": "FSM"
+  },
+  {
+    "name": "Moldova",
+    "code": "MOL"
+  },
+  {
+    "name": "Monaco",
+    "code": "MCO"
+  },
+  {
+    "name": "Mongolia",
+    "code": "MNG"
+  },
+  {
+    "name": "Montenegro",
+    "code": "MNE"
+  },
+  {
+    "name": "Montserrat",
+    "code": "MSR"
+  },
+  {
+    "name": "Morocco",
+    "code": "MAR"
+  },
+  {
+    "name": "Mozambique",
+    "code": "MOZ"
+  },
+  {
+    "name": "Namibia",
+    "code": "NAM"
+  },
+  {
+    "name": "Nauru",
+    "code": "NRU"
+  },
+  {
+    "name": "Nepal",
+    "code": "NPL"
+  },
+  {
+    "name": "Netherlands",
+    "code": "NLD"
+  },
+  {
+    "name": "New ZEALAND",
+    "code": "NZL"
+  },
+  {
+    "name": "Nicaragua",
+    "code": "NIC"
+  },
+  {
+    "name": "Niger",
+    "code": "NER"
+  },
+  {
+    "name": "Nigeria",
+    "code": "NGA"
+  },
+  {
+    "name": "Niue",
+    "code": "NIU"
+  },
+  {
+    "name": "Norway",
+    "code": "NOR"
+  },
+  {
+    "name": "Oman",
+    "code": "OMN"
+  },
+  {
+    "name": "Pakistan",
+    "code": "PAK"
+  },
+  {
+    "name": "Palestinian Occupied Territories",
+    "code": "XXP"
+  },
+  {
+    "name": "Panama",
+    "code": "PAN"
+  },
+  {
+    "name": "Papua New Guinea",
+    "code": "PNG"
+  },
+  {
+    "name": "Paraguay",
+    "code": "PRY"
+  },
+  {
+    "name": "Peru",
+    "code": "PER"
+  },
+  {
+    "name": "Philippines",
+    "code": "PHL"
+  },
+  {
+    "name": "Pitcairn Islands",
+    "code": "PCN"
+  },
+  {
+    "name": "Poland",
+    "code": "POL"
+  },
+  {
+    "name": "Portugal",
+    "code": "PRT"
+  },
+  {
+    "name": "Qatar",
+    "code": "QAT"
+  },
+  {
+    "name": "Romania",
+    "code": "ROM"
+  },
+  {
+    "name": "Russia",
+    "code": "RUS"
+  },
+  {
+    "name": "Rwanda",
+    "code": "RWA"
+  },
+  {
+    "name": "Samoa And Western Samoa",
+    "code": "WSM"
+  },
+  {
+    "name": "San Marino",
+    "code": "SMR"
+  },
+  {
+    "name": "Sao Tome and Principe",
+    "code": "STP"
+  },
+  {
+    "name": "Saudi Arabia",
+    "code": "SAU"
+  },
+  {
+    "name": "Senegal",
+    "code": "SEN"
+  },
+  {
+    "name": "Serbia",
+    "code": "SRB"
+  },
+  {
+    "name": "Seychelles",
+    "code": "SYC"
+  },
+  {
+    "name": "Sierra Leone",
+    "code": "SLE"
+  },
+  {
+    "name": "Singapore",
+    "code": "SGP"
+  },
+  {
+    "name": "Slovakia",
+    "code": "SVK"
+  },
+  {
+    "name": "Slovenia",
+    "code": "SVN"
+  },
+  {
+    "name": "Solomon Islands",
+    "code": "SLB"
+  },
+  {
+    "name": "Somalia",
+    "code": "SOM"
+  },
+  {
+    "name": "South Africa",
+    "code": "ZAF"
+  },
+  {
+    "name": "South Korea",
+    "code": "KOR"
+  },
+  {
+    "name": "South Sudan",
+    "code": "XXX"
+  },
+  {
+    "name": "Soviet Union",
+    "code": "SUN"
+  },
+  {
+    "name": "Spain",
+    "code": "ESP"
+  },
+  {
+    "name": "Sri Lanka",
+    "code": "LKA"
+  },
+  {
+    "name": "St Helena",
+    "code": "SHN"
+  },
+  {
+    "name": "St Kitts and Nevis",
+    "code": "KNA"
+  },
+  {
+    "name": "St Lucia",
+    "code": "LCA"
+  },
+  {
+    "name": "St Vincent",
+    "code": "VCT"
+  },
+  {
+    "name": "Sudan",
+    "code": "SDN"
+  },
+  {
+    "name": "Surinam",
+    "code": "SUR"
+  },
+  {
+    "name": "Swaziland",
+    "code": "SWZ"
+  },
+  {
+    "name": "Sweden",
+    "code": "SWE"
+  },
+  {
+    "name": "Switzerland",
+    "code": "CHE"
+  },
+  {
+    "name": "Syria",
+    "code": "SYR"
+  },
+  {
+    "name": "Taiwan",
+    "code": "TWN"
+  },
+  {
+    "name": "Tajikistan",
+    "code": "TDK"
+  },
+  {
+    "name": "Tanzania",
+    "code": "TZA"
+  },
+  {
+    "name": "Thailand",
+    "code": "THA"
+  },
+  {
+    "name": "Togo",
+    "code": "TGO"
+  },
+  {
+    "name": "Tonga",
+    "code": "TON"
+  },
+  {
+    "name": "Trinidad and Tobago",
+    "code": "TTO"
+  },
+  {
+    "name": "Tunisia",
+    "code": "TUN"
+  },
+  {
+    "name": "Turkey",
+    "code": "TUR"
+  },
+  {
+    "name": "Turkmenistan",
+    "code": "TKM"
+  },
+  {
+    "name": "Turks and Caicos Islands",
+    "code": "TCA"
+  },
+  {
+    "name": "Tuvalu",
+    "code": "TUV"
+  },
+  {
+    "name": "Uganda",
+    "code": "UGA"
+  },
+  {
+    "name": "Ukraine",
+    "code": "UKR"
+  },
+  {
+    "name": "United Arab Emirates",
+    "code": "ARE"
+  },
+  {
+    "name": "United Kingdom",
+    "code": "GBR"
+  },
+  {
+    "name": "United Nations",
+    "code": "UNO"
+  },
+  {
+    "name": "United States of America",
+    "code": "USA"
+  },
+  {
+    "name": "Uruguay",
+    "code": "URY"
+  },
+  {
+    "name": "Uzbekistan",
+    "code": "UZB"
+  },
+  {
+    "name": "Vanuatu",
+    "code": "VUT"
+  },
+  {
+    "name": "Vatican",
+    "code": "VAT"
+  },
+  {
+    "name": "Venezuela",
+    "code": "VEN"
+  },
+  {
+    "name": "Vietnam",
+    "code": "VNM"
+  },
+  {
+    "name": "Yemen",
+    "code": "YEM"
+  },
+  {
+    "name": "Yugoslavia",
+    "code": "YUG"
+  },
+  {
+    "name": "Zambia",
+    "code": "ZMB"
+  },
+  {
+    "name": "Zimbabwe",
+    "code": "ZWE"
+  }
+]

--- a/lib/flight-lookup.js
+++ b/lib/flight-lookup.js
@@ -1,0 +1,106 @@
+const request = require('request');
+const service = require('../config/config').flightService;
+const moment = require('moment');
+const momentTimezone = require('moment-timezone');
+const countries = require('../data/nationalities.json');
+const airports = require('../data/airports.json');
+const logger = require('../lib/logger');
+
+module.exports = {
+    findFlight: function(num, date) {
+        var method = service.check.method.toLowerCase();
+
+        return new Promise((resolve, reject) => {
+            request[method]({
+                url: `${service.url}/${service.check.endpoint}`,
+                json: { flightNumber: num, arrivalDate: date },
+                timeout: service.timeout
+            }, function (err, response, body) {
+                if (err) {
+                    logger.error(err);
+                    reject(err);
+                } else {
+                    logger.info(body);
+                    resolve(response);
+                }
+            });
+        });
+    },
+    // BA 1000 => BA1000
+    // BA09 => BA0009
+    // BAX-2094 => BAX2094
+    formatFlightNumber: function(num) {
+        // Remove white space and other symbols
+        var flightNo = num.replace(/[^A-Z0-9]/ig, '');
+
+        // get first instance of number
+        var match = flightNo.match(/\d+/);
+        var cut = match ? match.index : false;
+
+        if (!cut) {
+            return flightNo;
+        }
+
+        var carrierCode = flightNo.substring(0, cut).toUpperCase();
+        var number = flightNo.substring(cut);
+
+        // Pad the numbers with missing zeros if required
+        if (number.length < 4) {
+            number = ('0000' + number).slice(-4);
+        }
+
+        return carrierCode + number;
+    },
+    formatPost: function(body) {
+        return {
+            // sanitise user input
+            number: this.formatFlightNumber(body.flightNumber),
+            date: moment([
+                body.arrivalDateDay,
+                body.arrivalDateMonth,
+                body.arrivalDateYear
+            ].reverse().join('-'), 'YYYY-M-D').format('YYYY-MM-DD')
+        };
+    },
+    // map service response to useful form elements
+    mapFlight: function(flight, sessionModel) {
+        var arrivalDate = this.momentDate(flight.arrival);
+        var departCode = this.search(airports, {
+            key: 'code',
+            val: flight.departure.port
+        })['country-code'];
+
+        return {
+            flightNumber: sessionModel.get('flight-number'),
+            inwardDepartureCountryPlane: this.country(departCode),
+            inwardDepartureCountryPlaneCode: departCode,
+            departureAirport: this.airport(flight.departure.port),
+            inwardDeparturePortPlaneCode: flight.departure.port,
+            arrivalAirport: this.airport(flight.arrival.port),
+            portOfArrivalPlaneCode: flight.arrival.port,
+            arrivalDate: `${arrivalDate.format('DD')}/${arrivalDate.format('MM')}/${arrivalDate.format('YYYY')}`,
+            arrivalDatePlaneDay: arrivalDate.format('DD'),
+            arrivalDatePlaneMonth: arrivalDate.format('MM'),
+            arrivalDatePlaneYear: arrivalDate.format('YYYY'),
+            arrivalTime: `${arrivalDate.format('HH')}:${arrivalDate.format('mm')}`,
+            arrivalTimePlaneHour: arrivalDate.format('HH'),
+            arrivalTimePlaneMinutes: arrivalDate.format('mm'),
+            aliasFlightNumber: flight.aliasFlightNumber
+        };
+    },
+    momentDate: function(datetime) {
+      return momentTimezone.utc(`${datetime.date} ${datetime.time}`, 'YYYY-MM-DD HHmm').tz('Europe/London');
+    },
+    // Get an item from source json using a key
+    // search(countries, {key: 'code',val: 'ARE'})
+    search: (source, pair) => {
+      return source.find(obj => obj[pair.key] === pair.val) || false;
+    },
+    country: (code) => {
+      return (countries.find(obj => obj.code === code) || {}).name || false;
+    },
+    // DXB => Dubai and then derive country name from ARE
+    airport: (code) => {
+      return (airports.find(obj => obj.code === code) || {}).name || false;
+    }
+};

--- a/mocks/flight/post/details.js
+++ b/mocks/flight/post/details.js
@@ -1,0 +1,68 @@
+var tpl = function(params, query, body) {
+    return {
+        flightNumber: body.flightNumber,
+        departure: {
+            port: 'DXB',
+            country: 'AE'
+        },
+        arrival: {
+            port: 'LGW',
+            date: body.arrivalDate,
+            time: '1845'
+        }
+    };
+};
+
+module.exports = {
+    path: '/check-flight-details',
+    cache: false,
+    status: function(req, res) {
+        // mock fail state
+        if(req.body.flightNumber === 'FAIL999') {
+            res.status(500).send('Service is down');
+        } else {
+            res.status(200).json({
+                flights: this.template.flights(req.params, req.query, req.body)
+            });
+        }
+    },
+    template: {
+        flights: function (params, query, body) {
+
+            if (!body.flightNumber || !body.arrivalDate) {
+                return [];
+            }
+
+            // Fake up a no-flights scenario
+            if (body.flightNumber === 'NO0001') {
+                return [];
+            }
+
+            // fake up too many results
+            if (body.flightNumber === 'SUM1000') {
+                return [
+                    tpl(params, query, body),
+                    tpl(params, query, body)
+                ];
+            }
+
+            // fake up service is down
+            // Fake up sending incorrect information
+            return [{
+                flightNumber: body.flightNumber,
+                departure: {
+                    port: 'DXB',
+                    country: 'AE'
+                },
+                arrival: {
+                    port: 'LGW',
+                    date: body.arrivalDate,
+                    time: '1845'
+                },
+                params: params,
+                query: query,
+                body: body
+            }];
+        }
+    }
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   },
   "scripts": {
     "start": "node .",
+    "mock": "node ./node_modules/.bin/dyson mocks 9350",
     "dev": "npm-run-all --parallel watch:app watch:scss watch:js watch:translations",
+    "dev:mock": "npm-run-all --parallel dev mock",
+    "ci": "npm-run-all --parallel start mock",
     "watch:app": "NODE_ENV=development nodemon --watch apps -e html,json,js",
     "watch:scss": "nodemon -e scss -x 'npm run sass'",
     "watch:js": "nodemon --watch assets/js -x 'npm run browserify'",

--- a/package.json
+++ b/package.json
@@ -47,11 +47,13 @@
     "lodash": "^4.13.1",
     "moment": "^2.13.0",
     "moment-business": "^3.0.0",
+    "moment-timezone": "^0.5.4",
     "node-sass": "3.4.2",
     "nodemailer": "^2.4.2",
     "nodemailer-smtp-transport": "^2.5.0",
     "nodemailer-stub-transport": "^1.0.0",
     "redis": "^2.6.1",
+    "request": "^2.72.0",
     "typeahead.js-browserify": "^1.0.5",
     "underscore": "^1.8.3",
     "winston": "^1.*.*"

--- a/package.json
+++ b/package.json
@@ -63,9 +63,11 @@
   },
   "devDependencies": {
     "chai": "^3.0.0",
+    "chai-as-promised": "^5.3.0",
     "chromedriver": "^2.21.2",
     "cucumber": "^1.0.0",
     "debug": "^2.2.0",
+    "dyson": "^0.10.0",
     "eslint": "^2.11.1",
     "eslint-plugin-filenames": "^1.0.0",
     "eslint-plugin-mocha": "^3.0.0",

--- a/test/unit/apps/update-journey-details/lib/flight-lookup.spec.js
+++ b/test/unit/apps/update-journey-details/lib/flight-lookup.spec.js
@@ -1,0 +1,169 @@
+'use strict';
+
+let flightLookup = require('../../../../../lib/flight-lookup');
+let airports = require('../../../../../data/airports');
+let dyson = require('dyson');
+let chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+
+describe('lib/flight-lookup', function() {
+    describe('#findFlight', function() {
+        it('returns a 200 status code', function() {
+            let foundData = flightLookup.findFlight('KU0101', '2016-08-09');
+            return foundData.should.eventually.deep.have.property('statusCode', 200);
+        });
+
+        it('returns a valid flight object', function() {
+            let foundData = flightLookup.findFlight('KU0101', '2016-08-09');
+            return foundData.should.eventually.deep.have.property('body.flights[0]').to.equal({
+                flightNumber: 'KU0101',
+                departure: {
+                    country: 'AE',
+                    port: 'DXB'
+                },
+                arrival: {
+                    port: 'LGW',
+                    date: '2016-08-09',
+                    time: '1845'
+                },
+                params: {},
+                query: {},
+                body: {
+                    arrivalDate: '2016-08-09',
+                    flightNumber: 'KU0101'
+                }
+            });
+        });
+    });
+
+    describe('#formatFlightNumber', function() {
+        it('formats the flight number into the correct format for sending to the api', function() {
+            flightLookup.formatFlightNumber('ku101').should.equal('KU0101');
+        });
+    });
+
+    describe('#formatPost', function() {
+        it('formats the data into the correct format for sending to the api', function() {
+            let body = {
+                flightNumber: 'ku101',
+                arrivalDateDay: '09',
+                arrivalDateMonth: '08',
+                arrivalDateYear: '2016'
+            };
+            flightLookup.formatPost(body).should.deep.equal({
+                number: 'KU0101',
+                date: '2016-08-09'
+            });
+        });
+    });
+
+    describe('#mapFlight', function() {
+        it('formats the data from the api into the correct format to use in the app', function() {
+            let flight = {
+                flightNumber: 'KU0101',
+                departure: {
+                    country: 'KW', port: 'KWI'
+                },
+                arrival: {
+                    port: 'LHR',
+                    date: '2016-08-09',
+                    time: '1345'
+                }
+            };
+            let sessionModel = {
+                get: function (key) {
+                    return this.attributes[key];
+                },
+                attributes: {
+                    'flight-number': 'ku101'
+                }
+            };
+            flightLookup.mapFlight(flight, sessionModel).should.deep.equal({
+                flightNumber: 'ku101',
+                inwardDepartureCountryPlane: 'Kuwait',
+                inwardDepartureCountryPlaneCode: 'KWT',
+                departureAirport: 'Kuwait - Kuwait Intl',
+                inwardDeparturePortPlaneCode: 'KWI',
+                arrivalAirport: 'London - Heathrow',
+                portOfArrivalPlaneCode: 'LHR',
+                arrivalDate: '09/08/2016',
+                arrivalDatePlaneDay: '09',
+                arrivalDatePlaneMonth: '08',
+                arrivalDatePlaneYear: '2016',
+                arrivalTime: '14:45',
+                arrivalTimePlaneHour: '14',
+                arrivalTimePlaneMinutes: '45',
+                aliasFlightNumber: undefined
+            });
+        });
+    });
+
+    describe('#momentDate', function() {
+        let datetime = {
+            date: '2016-08-09',
+            time: '1345'
+        }
+
+        it('returns a moment object', function() {
+            flightLookup.momentDate(datetime).should.contain.property('_isAMomentObject', true);
+        });
+
+        it('returns a valid date', function() {
+            flightLookup.momentDate(datetime).should.contain.property('_isValid', true);
+        });
+
+        it('returns the correct date', function() {
+            flightLookup.momentDate(datetime).should.contain.property('_i', '2016-08-09 1345');
+        });
+    });
+
+    describe('#search', function() {
+        describe('when searching a data file', function() {
+            it('returns an object if the value is found', function() {
+                let pair = {
+                    key: 'code',
+                    val: 'KWI'
+                };
+                flightLookup.search(airports, pair).should.deep.equal({
+                    type: 'plane',
+                    country: 'Kuwait',
+                    'country-code': 'KWT',
+                    code: 'KWI',
+                    name: 'Kuwait - Kuwait Intl'
+                });
+            });
+
+            it("returns false if the value isn't found", function() {
+                let pair = {
+                    key: 'code',
+                    val: 'kwi'
+                };
+                flightLookup.search(airports, pair).should.be.false;
+            });
+        })
+    });
+
+    describe('#country', function() {
+        describe('when searching the countries data file', function() {
+            it('returns a country object if the country is found', function() {
+                flightLookup.country('KWT').should.equal('Kuwait');
+            });
+
+            it("returns false if the country isn't found", function() {
+                flightLookup.country('kwt').should.be.false;
+            });
+        });
+    });
+
+    describe('#airport', function() {
+        describe('when searching the airports data file', function() {
+            it('returns an airport object if the airport is found', function() {
+                flightLookup.airport('DXB').should.equal('Dubai');
+            });
+
+            it("returns false if the airport isn't found", function() {
+                flightLookup.airport('dxb').should.be.false;
+            });
+        });
+    });
+});


### PR DESCRIPTION
✈️ ✈️ 
Added flight service so we can now return proper flight data 

Acceptance tests to check for:
- A correct flight then proceeding to declaration page
- An incorrect flight found and returning to enter a different flight number
- A flight which isn't found

Unit tests for the flight lookup module using dyson to mock the api

Added `npm run dev:mock` to start the app and use the mock flight api
✈️ ✈️