### PR TITLE
[NIJ] update-journey-details: Show summary data

### DIFF
--- a/acceptance_tests/features/step_definitions/check-your-answers.js
+++ b/acceptance_tests/features/step_definitions/check-your-answers.js
@@ -4,7 +4,7 @@ module.exports = function () {
 
     this.Then(/^the summary table should contain$/, function (strings) {
         strings.split(/\n/).forEach( function (string) {
-            this.assert.containsText('#summary', string);
+            this.assert.containsText('#summary', string.trim());
         }, this);
     });
 

--- a/acceptance_tests/features/step_definitions/general.js
+++ b/acceptance_tests/features/step_definitions/general.js
@@ -20,6 +20,10 @@ module.exports = function () {
         this.assert.urlEquals(setUrl(app, page));
     });
 
+    this.Given(/^I sleep for "([^"]*)"$/, function (time) {
+        this.pause(time*1000);
+    });
+
     this.When(/^I click "([^"]*)"$/, function (value) {
         this.click(`input[value=${urlise(value)}]`);
     });

--- a/acceptance_tests/features/update-journey-details.feature
+++ b/acceptance_tests/features/update-journey-details.feature
@@ -14,7 +14,7 @@ Scenario: Entering new flight details and correct flight found
   # Arrival date page
   Then I should be on the "Arrival date" page of the "Update journey details" app
   And the page title should contain "Your new flight details"
-  And I enter the date "09-08-2016" into "Arrival date"
+  And I enter the date "10-08-2016" into "Arrival date"
   And I continue
   # Is this your flight page
   Then I should be on the "Is this your flight" page of the "Update journey details" app
@@ -22,7 +22,7 @@ Scenario: Entering new flight details and correct flight found
   And the "Flight number" should contain "KU101"
   And the "Departure airport" should contain "Dubai"
   And the "Arrival airport" should contain "London - Gatwick"
-  And the "Arrival date" should contain "09/08/2016"
+  And the "Arrival date" should contain "10/08/2016"
   And the "Arrival time" should contain "19:45"
   And I click "Yes"
   And I continue
@@ -30,13 +30,26 @@ Scenario: Entering new flight details and correct flight found
   Then I should be on the "Departure date and time" page of the "Update journey details" app
   And the page title should contain "Your journey to the UK"
   And I enter the date "09-08-2016" into "Departure date"
-  And I enter the time "12:23" into "Departure time"
+  And I enter the time "23:15" into "Departure time"
   And I continue
   # Check your answers page
   Then the page title should contain "Check your answers"
   And the summary table should contain
     """
-    KU101
+    Departure airport
+                      Dubai
+    Departure date
+                      09-08-2016
+    Departure time
+                      23:15
+    Flight number
+                      KU101
+    Arrival airport
+                      London - Gatwick
+    Arrival date
+                      10-08-2016
+    Arrival time
+                      19:45
     """
   And I continue
   # Declaration page

--- a/apps/common/controllers/evw-base.js
+++ b/apps/common/controllers/evw-base.js
@@ -11,15 +11,21 @@ const options = {
 };
 const formatting = require('../../../lib/formatting');
 
+
 let EvwBaseController = function EvwBaseController() {
-  this.dateFormat = 'DD-MM-YYYY';
   DateController.apply(this, arguments);
 };
 
 util.inherits(EvwBaseController, DateController);
 
-EvwBaseController.prototype.process = function process(req, res, callback) {
+// A hack because Ralph can't figure out
+// passing options to a constructor 🙍🏽
+EvwBaseController.prototype.getNextStep = function (req, res) {
+  this.confirmStep = '/check-your-answers';
+  return DateController.prototype.getNextStep.call(this, req, res);
+}
 
+EvwBaseController.prototype.process = function process(req, res, callback) {
   return DateController.prototype.process.call(this, req, res, function processTime() {
     if(this.timeKey) {
       req.form.values[this.timeKey] = formatting.getTime(req.form.values, this.timeKey);

--- a/apps/common/controllers/evw-base.js
+++ b/apps/common/controllers/evw-base.js
@@ -9,18 +9,33 @@ const logger = require('../../../lib/logger');
 const options = {
   fullMessages: false,
 };
+const formatting = require('../../../lib/formatting');
 
 let EvwBaseController = function EvwBaseController() {
+  this.dateFormat = 'DD-MM-YYYY';
   DateController.apply(this, arguments);
 };
 
 util.inherits(EvwBaseController, DateController);
 
-EvwBaseController.prototype.applyDates = function firstDates(fields) {
+EvwBaseController.prototype.process = function process(req, res, callback) {
+
+  return DateController.prototype.process.call(this, req, res, function processTime() {
+    if(this.timeKey) {
+      req.form.values[this.timeKey] = formatting.getTime(req.form.values, this.timeKey);
+    }
+    callback();
+  }.bind(this));
+};
+
+EvwBaseController.prototype.applyDatesTimes = function firstDates(fields) {
   Object.keys(fields).forEach((key) => {
     let type = fields[key].type;
     if(type && type.indexOf('date') > -1) {
       this.dateKey = key;
+    };
+    if(type && type.indexOf('time') > -1) {
+      this.timeKey = key;
     };
   });
 }
@@ -28,11 +43,11 @@ EvwBaseController.prototype.applyDates = function firstDates(fields) {
 // Format date/time
 let formatValue = (formValues, key) => {
   if(key.match(/dob$|date$/gi) ) {
-    return `${formValues[key + '-year']}-${formValues[key + '-month']}-${formValues[key + '-day']}`;
+    return formatting.getDate(formValues, key);
   }
 
   if (key.indexOf('time') > -1) {
-    return `${formValues[key + '-hours']}:${formValues[key + '-minutes']}`;
+    return formatting.getTime(formValues, key);
   }
 
   return formValues[key];

--- a/apps/find-your-application/controllers/enter-your-details.js
+++ b/apps/find-your-application/controllers/enter-your-details.js
@@ -8,7 +8,7 @@ module.exports = class EnterYourDetailsController extends EvwBaseController {
 
   constructor(options) {
     super(options);
-    super.applyDates(options.fields);
+    super.applyDatesTimes(options.fields);
   }
 
   process(req, res, callback) {

--- a/apps/update-journey-details/controllers/departure-date-and-time.js
+++ b/apps/update-journey-details/controllers/departure-date-and-time.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const EvwBaseController = require('../../common/controllers/evw-base');
+
+module.exports = class EnterYourDetailsController extends EvwBaseController {
+
+  constructor(options) {
+    super(options);
+    super.applyDatesTimes(options.fields);
+  }
+}

--- a/apps/update-journey-details/fields/departure-date-and-time.js
+++ b/apps/update-journey-details/fields/departure-date-and-time.js
@@ -2,27 +2,31 @@
 
 module.exports = {
   'departure-date': {
+    type: [ 'date' ],
+    validate: [] // blanked out validation because 'future was being applied for some wtf reason'
   },
   'departure-date-day': {
-      validate: ['required', 'numeric'],
-      label: 'fields.departure-date-day.label'
+    validate: ['required', 'numeric'],
+    label: 'fields.departure-date-day.label'
   },
   'departure-date-month': {
-      validate: ['required', 'numeric'],
-      label: 'fields.departure-date-month.label'
+    validate: ['required', 'numeric'],
+    label: 'fields.departure-date-month.label'
   },
   'departure-date-year': {
-      validate: ['required', 'numeric'],
-      label: 'fields.departure-date-year.label'
+    validate: ['required', 'numeric'],
+    label: 'fields.departure-date-year.label'
   },
   'departure-time': {
+    validate: [ 'required' ],
+    type: [ 'time' ]
   },
   'departure-time-hours': {
-      validate: ['required', 'numeric'],
-      label: 'fields.departure-time-hours.label'
+    validate: ['required', 'numeric'],
+    label: 'fields.departure-time-hours.label'
   },
   'departure-time-minutes': {
-      validate: ['required', 'numeric'],
-      label: 'fields.departure-time-minutes.label'
+    validate: ['required', 'numeric'],
+    label: 'fields.departure-time-minutes.label'
   }
 };

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -66,7 +66,7 @@ module.exports = {
   },
   '/departure-date-and-time': {
     template: 'departure-date-and-time',
-    controller: require('../common/controllers/evw-base'),
+    controller: require('./controllers/departure-date-and-time'),
     fields: [
       'departure-date',
       'departure-date-day',

--- a/apps/update-journey-details/translations/src/en/validation.json
+++ b/apps/update-journey-details/translations/src/en/validation.json
@@ -27,6 +27,7 @@
     "in-future": "The date your flight to the UK takes off cannot be after the date it arrives in the UK"
   },
   "departure-time": {
+    "required": "Please enter a time",
     "departure-after-arrival": "Your departure cannot be after your arrival",
     "departure-too-far-before-arrival": "The date your flight to the UK takes off cannot be more than 24 hours before it arrives in the UK"
   }

--- a/apps/update-journey-details/translations/src/en/validation.json
+++ b/apps/update-journey-details/translations/src/en/validation.json
@@ -12,7 +12,7 @@
     "numeric": "Enter a valid date",
     "invalid": "Enter the time your flight is due to land in the UK in 24 hour format HH:MM",
     "within-48-hours": "Date of arrival must be at least 48 hours from now",
-    "to-far-in-future": "Date of arrival in the UK must be no more than 3 months from now"
+    "too-far-in-future": "Date of arrival in the UK must be no more than 3 months from now"
   },
   "is-this-your-flight": {
     "required": "Please select an option",

--- a/apps/update-journey-details/views/check-your-answers.html
+++ b/apps/update-journey-details/views/check-your-answers.html
@@ -77,8 +77,10 @@
         </tr>
     </tbody>
 </table>
-
-{{#input-submit}}Confirm submission{{/input-submit}}
+<p>
+    <br>
+    {{#input-submit}}Confirm submission{{/input-submit}}
+</p>
 {{/form}}
 
 {{/partials-form}}

--- a/apps/update-journey-details/views/check-your-answers.html
+++ b/apps/update-journey-details/views/check-your-answers.html
@@ -31,21 +31,21 @@
             <td>
                 {{values.flightDetails.departureAirport}}
             </td>
-            <td><a href="#" class="button" id="example-radio-change">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="flight-number#edit#flight-number" class="button" id="">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
         <tr>
             <td>{{#t}}pages.check-your-answers.table.departure-date{{/t}}</td>
             <td>
                 {{values.departure-date}}
             </td>
-            <td><a href="departure-date-and-time/edit#departure-date" class="button" id="example-radio-change">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="departure-date-and-time/edit#departure-date" class="button" id="">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
         <tr>
             <td>{{#t}}pages.check-your-answers.table.departure-time{{/t}}</td>
             <td>
                 {{values.departure-time}}
             </td>
-            <td><a href="departure-date-and-time/edit#departure-time" class="button" id="example-radio-change">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="departure-date-and-time/edit#departure-time" class="button" id="">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
         <tr>
             <td>{{#t}}pages.check-your-answers.table.flight-number{{/t}}</td>
@@ -59,21 +59,21 @@
             <td>
                 {{values.flightDetails.arrivalAirport}}
             </td>
-            <td><a href="#" class="button" id="example-radio-change">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="flight-number#edit#flight-number" class="button" id="">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
         <tr>
             <td>{{#t}}pages.check-your-answers.table.arrival-date{{/t}}</td>
             <td>
                 {{values.arrival-date}}
             </td>
-            <td><a href="arrival-date/edit#arrival-date" class="button" id="example-radio-change">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="arrival-date/edit#arrival-date" class="button" id="">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
         <tr>
             <td>{{#t}}pages.check-your-answers.table.arrival-time{{/t}}</td>
             <td>
                 {{values.flightDetails.arrivalTime}}
             </td>
-            <td><a href="#" class="button" id="example-radio-change">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="arrival-date/edit#arrival-time" class="button" id="">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
     </tbody>
 </table>

--- a/lib/formatting.js
+++ b/lib/formatting.js
@@ -6,6 +6,11 @@ const getTime = (values, key) => {
   ).format('HH:mm');
 }
 
+const getDate = (values, key) => {
+  return moment(`${values[key + '-day']}-${values[key + '-month']}-${values[key + '-year']}`, 'DD-MM-YYYY').format('DD-MM-YYYY');
+}
+
 module.exports = {
-  getTime: getTime
+  getTime: getTime,
+  getDate: getDate
 }

--- a/lib/formatting.js
+++ b/lib/formatting.js
@@ -1,0 +1,11 @@
+const moment = require('moment');
+
+const getTime = (values, key) => {
+  return moment(
+    `${values[key + '-hours']}:${values[key + '-minutes']}`, 'HH:mm'
+  ).format('HH:mm');
+}
+
+module.exports = {
+  getTime: getTime
+}

--- a/lib/formatting.js
+++ b/lib/formatting.js
@@ -1,9 +1,15 @@
+'use strict';
+
 const moment = require('moment');
 
 const getTime = (values, key) => {
-  return moment(
+  let time = moment(
     `${values[key + '-hours']}:${values[key + '-minutes']}`, 'HH:mm'
   ).format('HH:mm');
+  if (`${values[key + '-hours']}${values[key + '-minutes']}` === '') {
+   time = '';
+  }
+  return time;
 }
 
 const getDate = (values, key) => {

--- a/test/lib/formatting.spec.js
+++ b/test/lib/formatting.spec.js
@@ -28,7 +28,7 @@ describe('lib/formatting', function () {
       values['departure-time-hours'] = '';
       values['departure-time-minutes'] = '';
       formatting.getTime(values, 'departure-time')
-      .should.equal('Invalid date');
+      .should.equal('');
     });
 
     it('derives 00mins when hour passed', function () {

--- a/test/lib/formatting.spec.js
+++ b/test/lib/formatting.spec.js
@@ -2,8 +2,8 @@
 
 const formatting = require('../../lib/formatting');
 let values = {
-    'departure-date': '10-10-2016',
-    'departure-date-day': '10',
+    'departure-date': '',
+    'departure-date-day': '24',
     'departure-date-month': '10',
     'departure-date-year': '2016',
     'departure-time': '',
@@ -36,6 +36,21 @@ describe('lib/formatting', function () {
       values['departure-time-minutes'] = '';
       formatting.getTime(values, 'departure-time')
       .should.equal('18:00');
+    });
+  });
+
+  describe('#getDate', function () {
+    it('formats as DD-MM-YYYY', function () {
+      formatting.getDate(values, 'departure-date')
+      .should.equal('24-10-2016');
+    });
+
+    it('pads to DD-MM-YYYY', function () {
+      values['departure-date-day'] = '2'
+      values['departure-date-month'] = '3'
+      values['departure-date-year'] = '16'
+      formatting.getDate(values, 'departure-date')
+      .should.equal('02-03-2016');
     });
   });
 });

--- a/test/lib/formatting.spec.js
+++ b/test/lib/formatting.spec.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const formatting = require('../../lib/formatting');
+let values = {
+    'departure-date': '10-10-2016',
+    'departure-date-day': '10',
+    'departure-date-month': '10',
+    'departure-date-year': '2016',
+    'departure-time': '',
+    'departure-time-hours': '2',
+    'departure-time-minutes': '1'
+};
+
+describe('lib/formatting', function () {
+  describe('#getTime', function () {
+    it('pads numbers', function () {
+      formatting.getTime(values, 'departure-time')
+      .should.equal('02:01');
+    });
+
+    it('maintains padding', function () {
+      values['departure-time-hours'] = '02';
+      formatting.getTime(values, 'departure-time')
+      .should.equal('02:01');
+    });
+
+    it('does not accept blank values', function () {
+      values['departure-time-hours'] = '';
+      values['departure-time-minutes'] = '';
+      formatting.getTime(values, 'departure-time')
+      .should.equal('Invalid date');
+    });
+
+    it('derives 00mins when hour passed', function () {
+      values['departure-time-hours'] = '18';
+      values['departure-time-minutes'] = '';
+      formatting.getTime(values, 'departure-time')
+      .should.equal('18:00');
+    });
+  });
+});

--- a/test/unit/validation/arrival-date.spec.js
+++ b/test/unit/validation/arrival-date.spec.js
@@ -5,7 +5,7 @@ const moment = require('moment');
 
 describe('validation/arrival-date', function() {
   it('should be a valid date', function() {
-    validation.rules('2016-08-32').should.deep.equal({
+    validation.rules('32-08-2016').should.deep.equal({
       length: {
         minimum: 12,
         message: 'arrival-date.invalid'
@@ -17,7 +17,7 @@ describe('validation/arrival-date', function() {
     validation.rules(moment().add(4, 'months')).should.deep.equal({
       length: {
         minimum: 12,
-        message: 'arrival-date.to-far-in-future'
+        message: 'arrival-date.too-far-in-future'
       }
     });
   });

--- a/test/unit/validation/departure-date.spec.js
+++ b/test/unit/validation/departure-date.spec.js
@@ -16,7 +16,7 @@ describe('validation/departure-date', function() {
       'arrival-date': moment().subtract(1, 'day')
     }
 
-    validation.rules('2016-08-32', model).should.deep.equal({
+    validation.rules('32-08-2016', model).should.deep.equal({
       length: {
         minimum: 12,
         message: 'departure-date.invalid'

--- a/validation/arrival-date.js
+++ b/validation/arrival-date.js
@@ -21,7 +21,7 @@ module.exports = {
       return {
         length: {
           minimum: 12,
-          message: 'arrival-date.to-far-in-future'
+          message: 'arrival-date.too-far-in-future'
         }
       };
     }

--- a/validation/arrival-date.js
+++ b/validation/arrival-date.js
@@ -4,7 +4,7 @@ const moment = require('moment');
 
 module.exports = {
   rules: (fieldValue) => {
-    let date = moment(fieldValue, 'YYYY-M-D');
+    let date = moment(fieldValue, 'DD-MM-YYYY');
     let threeMonths = moment().add(3, 'months');
     let fourtyEight = moment().add(48, 'hours');
 

--- a/validation/departure-date.js
+++ b/validation/departure-date.js
@@ -4,9 +4,9 @@ const moment = require('moment');
 
 module.exports = {
   rules: (fieldValue, model) => {
-    let departureDate = moment(fieldValue, 'YYYY-M-D');
-    let arrivalDateMinusOneDay = moment(model.get('arrival-date'), 'YYYY-M-D').subtract(1, 'day');
-    let arrivalDatePlusOneDay = moment(model.get('arrival-date'), 'YYYY-M-D').add(1, 'day');
+    let departureDate = moment(fieldValue, 'DD-MM-YYYY');
+    let arrivalDateMinusOneDay = moment(model.get('arrival-date'), 'DD-MM-YYYY').subtract(1, 'day');
+    let arrivalDatePlusOneDay = moment(model.get('arrival-date'), 'DD-MM-YYYY').add(1, 'day');
 
     if (!departureDate.isValid()) {
       return {

--- a/validation/departure-date.js
+++ b/validation/departure-date.js
@@ -5,8 +5,8 @@ const moment = require('moment');
 module.exports = {
   rules: (fieldValue, model) => {
     let departureDate = moment(fieldValue, 'YYYY-M-D');
-    let arrivalDateMinusOneDay = moment(model.get('arrival-date')).subtract(1, 'day');
-    let arrivalDatePlusOneDay = moment(model.get('arrival-date')).add(1, 'day');
+    let arrivalDateMinusOneDay = moment(model.get('arrival-date'), 'YYYY-M-D').subtract(1, 'day');
+    let arrivalDatePlusOneDay = moment(model.get('arrival-date'), 'YYYY-M-D').add(1, 'day');
 
     if (!departureDate.isValid()) {
       return {

--- a/validation/departure-time.js
+++ b/validation/departure-time.js
@@ -4,8 +4,8 @@ const moment = require('moment');
 
 module.exports = {
   rules: (fieldValue, model) => {
-    let departureDateTime = moment(`${model.get('departure-date')} ${fieldValue}`, 'YYYY-M-D h:m');
-    let arrivalDateTime = moment(`${model.get('arrival-date')} ${model.get('flightDetails').arrivalTime}`, 'YYYY-M-D h:m');
+    let departureDateTime = moment(`${model.get('departure-date')} ${fieldValue}`, 'DD-MM-YYYY h:m');
+    let arrivalDateTime = moment(`${model.get('arrival-date')} ${model.get('flightDetails').arrivalTime}`, 'DD-MM-YYYY h:m');
 
     // We allow time travel of one hour max to compensate for time-zone hopping
     // `departure-time: 8:00` => `arrival-time: 7:00` is okay


### PR DESCRIPTION
### check your answers improvements ☑️

- adds gap between table and `'Confirm details` button
- all form entries are now displayed

![electronic visa wavier gov uk](https://cloud.githubusercontent.com/assets/120181/16846531/ad5d7726-49e4-11e6-8f11-6fc72cbbc69e.jpg)

### Date/Time formatting ⏲

- Date formats are now all `'DD-MM-YYYY'` (we can change this at some point if needed but this normalises e.g. arrival date and departure date formats)
- Adds in `lib/formatting` for all our date/time retrieving and parsing needs

### Edit => Confirm step now directs to `/check-your-answers`

- Before it was going to the default of `/confirm`, which is a url we don't supply
- This is done in a slightly hacky way because I couldn't figure out how constructor options were supposed to work 
- instead it hijacks the `getNextStep` method and insert a new `confirmStep` option there 

