### PR TITLE
[NIJ] Spin up/kill dyson programmatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "chai": "^3.0.0",
     "chai-as-promised": "^5.3.0",
     "chromedriver": "^2.21.2",
+    "colour": "^0.7.1",
     "cucumber": "^1.0.0",
     "debug": "^2.2.0",
     "dyson": "^0.10.0",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -5,6 +5,7 @@ globals:
   expect: true
   sinon: true
   should: true
+  dysonServer: true
 rules:
   func-names: 0
   max-nested-callbacks: 0

--- a/test/common.js
+++ b/test/common.js
@@ -7,10 +7,27 @@ global.should = chai.should();
 global.sinon = require('sinon');
 require('sinomocha')();
 require('moment-business');
-
-// bring up evw-integration-stub
-require('evw-integration-stub')();
+require('colour');
 
 process.env.NODE_ENV = 'test';
 process.setMaxListeners(0);
 process.stdout.setMaxListeners(0);
+
+const path = require('path');
+const spawn = require('child_process').spawn;
+
+global.dysonServer = (options, doneCallback) => {
+  let name = options.name || 'Dyson';
+  let cmd = spawn('node', ['./node_modules/.bin/dyson', path.resolve(options.mocks), options.port]);
+
+  cmd.stdout.on('data', (data) => {
+    console.log(' ', data.toString().replace(/dyson/i, name).green);
+    doneCallback();
+  });
+
+  cmd.on('close', (code, signal) => {
+    console.log(`   ${name} terminated (${signal})`.yellow);
+  });
+
+  return cmd;
+}

--- a/test/lib/evw-lookup.spec.js
+++ b/test/lib/evw-lookup.spec.js
@@ -9,6 +9,19 @@ let lookup;
 
 describe('lib/evw-lookup', function () {
 
+  // bring up evw-integration-stub
+  before(function (done){
+    this.dyson = dysonServer({
+      mocks: './node_modules/evw-integration-stub/mocks',
+      port: 9300,
+      name: 'integration service stub'
+    }, done);
+  });
+
+  after(function () {
+    this.dyson.kill();
+  });
+
   lookup = proxyquire('../../lib/evw-lookup', {
     logger: log
   });

--- a/test/unit/apps/update-journey-details/lib/flight-lookup.spec.js
+++ b/test/unit/apps/update-journey-details/lib/flight-lookup.spec.js
@@ -3,20 +3,24 @@
 const path = require('path');
 let flightLookup = require('../../../../../lib/flight-lookup');
 let airports = require('../../../../../data/airports');
-let dyson = require('dyson');
 let chaiAsPromised = require('chai-as-promised');
 let config = require('../../../../../config');
 chai.use(chaiAsPromised);
 
 describe('lib/flight-lookup', function() {
 
-    before(function () {
+    before(function (done) {
         let port = config.flightService.url.split(':').pop();
         let dir = path.resolve(__dirname, '../../../../../mocks');
-        dyson.bootstrap({
+        this.dyson = dysonServer({
+          mocks: dir,
           port: port,
-          configDir: dir
-        });
+          name: 'flight lookup service'
+        }, done);
+    });
+
+    after(function () {
+      this.dyson.kill();
     });
 
     describe('#findFlight', function() {


### PR DESCRIPTION
- Allows us to spin up and kill dyson stub serving within the context of the mocha runtime
- This means running e.g. `mocha -w` won't break the second time your tests run due to port collision errors
- It's not the most elegant thing but what is elegance anyway