### PR TITLE
[NIJ?] update-journey-details: check valid number/token

### DIFF
--- a/acceptance_tests/features/step_definitions/general.js
+++ b/acceptance_tests/features/step_definitions/general.js
@@ -39,6 +39,10 @@ module.exports = function () {
         this.click(`input[value=${urlise(value)}]`);
     });
 
+    this.When(/^I click id "([^"]*)"$/, function (id) {
+        this.click('#'+urlise(id));
+    });
+
     this.When(/^I enter "([^"]*)" into "([^"]*)"$/, function (value, field) {
         this.setValue('#'+urlise(field), value);
     });

--- a/acceptance_tests/features/step_definitions/general.js
+++ b/acceptance_tests/features/step_definitions/general.js
@@ -6,14 +6,25 @@ const setUrl = (app, page) => `${base}/${urlise(app)}/${page ? urlise(page) : ''
 
 module.exports = function () {
 
+    this.When(/^I start the "([^"]*)" app$/, function (app) {
+        this.url(setUrl(app))
+        .waitForElementVisible('body', 1000);
+    });
+
     this.When(/^I (?:start on|go to) the "([^"]*)" page of the "([^"]*)" app$/, function (page, app) {
         this.url(setUrl(app, page))
         .waitForElementVisible('body', 1000);
     });
 
-    this.When(/^I start the "([^"]*)" app$/, function (app) {
-        this.url(setUrl(app))
+    this.Given(/^I start the Update journey details app$/, function () {
+        this.url(`${base}/update-journey-details/how-will-you-arrive?evwNumber=evw-number&token=token`)
+
+
         .waitForElementVisible('body', 1000);
+    });
+
+    this.When(/^I wait for "([^"]*)"$/, function (time) {
+        this.pause(time*1000);
     });
 
     this.Given(/^I (?:am|should be) on the "([^"]*)" page of the "([^"]*)" app$/, function (page, app) {

--- a/acceptance_tests/features/update-journey-details.feature
+++ b/acceptance_tests/features/update-journey-details.feature
@@ -61,10 +61,13 @@ Scenario: Entering new flight details and correct flight found
     On changing my flight details my old electronic visa waiver document will be invalid and I will not use it to try to enter the UK; if I do so I may be denied boarding or be refused entry at the UK border.
     If I have completed this for someone else I have their full agreement.
     """
+  When I click id "Accept Declaration"
+  And I continue
+  Then I should be on the "Confirmation" page of the "Update journey details" app
 
 Scenario: Entering new flight details and flight not found
 
-  Given I start the "Update journey details" app
+  Given I start the Update journey details app
   Then the page title should contain "Your new journey to the UK"
   When I click "By plane"
   And I continue
@@ -83,7 +86,7 @@ Scenario: Entering new flight details and flight not found
 
 Scenario: Entering new flight details and incorrect flight found
 
-  Given I start the "Update journey details" app
+  Given I start the Update journey details app
   Then the page title should contain "Your new journey to the UK"
   When I click "By plane"
   And I continue
@@ -109,7 +112,7 @@ Scenario: Entering new flight details and incorrect flight found
   Then I should be on the "Flight number" page of the "Update journey details" app
 
 Scenario: Choosing Train
-  Given I start the "Update journey details" app
+  Given I start the Update journey details app
   When I click "By train"
   And I continue
   Then I should be on the "Email us" page of the "Update journey details" app
@@ -127,7 +130,7 @@ Scenario: Choosing Train
 
 Scenario: Choosing Private Plane
 
-  Given I start the "Update journey details" app
+  Given I start the Update journey details app
   When I click "By private plane"
   And I continue
   Then I should be on the "Email us" page of the "Update journey details" app
@@ -145,7 +148,7 @@ Scenario: Choosing Private Plane
 
 Scenario: Choosing Boat
 
-  Given I start the "Update journey details" app
+  Given I start the Update journey details app
   When I click "By boat"
   And I continue
   Then I should be on the "Email us" page of the "Update journey details" app
@@ -163,7 +166,7 @@ Scenario: Choosing Boat
 
 Scenario: Choosing Land
 
-  Given I start the "Update journey details" app
+  Given I start the Update journey details app
   When I click "By land"
   And I continue
   Then I should be on the "Email us" page of the "Update journey details" app

--- a/acceptance_tests/features/update-journey-details.feature
+++ b/acceptance_tests/features/update-journey-details.feature
@@ -3,7 +3,7 @@ Feature: Updating Journey Details
 
 Scenario: Entering new flight details and correct flight found
 
-  Given I start the "Update journey details" app
+  Given I start the Update journey details app
   Then the page title should contain "Your new journey to the UK"
   When I click "By plane"
   And I continue

--- a/apps/update-journey-details/controllers/how-will-you-arrive.js
+++ b/apps/update-journey-details/controllers/how-will-you-arrive.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const path = require('path');
+const hof = require('hof');
+const i18n = hof.i18n({
+  path: path.resolve(__dirname, '../../common/translations/__lng__/__ns__.json')
+});
+const EvwBaseController = require('../../common/controllers/evw-base');
+const request = require('request');
+const is = require('../../../config').integrationService;
+
+const fourOhfourIt = (res) => {
+  return res.status(404).render('404', {
+    title: i18n.translate('errors.404.title'),
+    description: i18n.translate('errors.404.description')
+  });
+}
+
+const checkValidated = (req, res, callback) => {
+  let valid = req.sessionModel.get('validated');
+  if(valid) {
+    callback();
+  } else {
+    validateApp(req,res,callback);
+  }
+};
+
+const validateApp = (req, res, callback) => {
+  let evwNumber = req.query.evwNumber;
+  let token = req.query.token;
+
+  if(!evwNumber || !token) {
+    return fourOhfourIt(res);
+  }
+
+  request[is.check.method.toLowerCase()]({
+    url: [
+        is.url,
+        is.check.endpoint,
+        evwNumber,
+        token
+    ].join('/'),
+    headers: {
+        'Content-Type': 'application/json'
+    },
+    timeout: is.timeout
+  }, function (err, response, body) {
+    var json = JSON.parse(body);
+
+    // 404 it in lieu of a more specific error page
+    if (json.error) {
+      req.sessionModel.reset();
+      return fourOhfourIt(res);
+      /* eslint no-warning-comments: 1*/
+      // TODO change to a invalid page
+    }
+
+    req.sessionModel.set('validated', true);
+    req.sessionModel.set('evw-number', evwNumber);
+    req.sessionModel.set('token', token);
+    return callback();
+  });
+}
+
+module.exports = class HowWillYouArriveController extends EvwBaseController {
+  getValues(req, res, callback) {
+    return checkValidated(req, res, callback);
+  }
+}

--- a/apps/update-journey-details/index.js
+++ b/apps/update-journey-details/index.js
@@ -22,8 +22,7 @@ router.use(mixins(fields, {
 router.use('/update-journey-details/', wizard(require('./steps'), fields, {
   controller: BaseController,
   templatePath: path.resolve(__dirname, 'views'),
-  translate: i18n.translate.bind(i18n),
-  params: '/:action?'
+  translate: i18n.translate.bind(i18n)
 }));
 
 module.exports = router;

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -9,6 +9,7 @@ module.exports = {
   },
   '/how-will-you-arrive': {
     template: 'how-will-you-arrive',
+    controller: require('./controllers/how-will-you-arrive'),
     fields: [
       'transport-options'
     ],

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -3,10 +3,10 @@
 let features = require('characteristic')(__dirname + '/../../config/features.yml');
 
 module.exports = {
-  '/': {
-    controller: require('../common/controllers/start'),
-    next: '/how-will-you-arrive'
-  },
+  // '/': {
+  //   controller: require('../common/controllers/start'),
+  //   next: '/how-will-you-arrive'
+  // },
   '/how-will-you-arrive': {
     template: 'how-will-you-arrive',
     controller: require('./controllers/how-will-you-arrive'),
@@ -92,7 +92,9 @@ module.exports = {
     fields: [
       'accept-declaration'
     ],
-    next: '/next-page',
-    clearSession: true
+    next: '/confirmation'
+  },
+  '/confirmation': {
+    template: 'confirmation'
   }
 };

--- a/apps/update-journey-details/views/confirmation.html
+++ b/apps/update-journey-details/views/confirmation.html
@@ -1,0 +1,23 @@
+{{<layout}}
+{{$step}}Step 8 of 8{{/step}}
+
+{{$journeyHeader}}
+{{#t}}journey.header{{/t}}
+{{/journeyHeader}}
+
+{{$validationSummary}}
+{{> partials-validation-summary}}
+{{/validationSummary}}
+
+{{$propositionHeader}}
+{{> partials-navigation}}
+{{/propositionHeader}}
+
+
+{{$content}}
+<h1 class="heading-large">TODO: {{#t}}pages.confirmation.header{{/t}}</h1>
+<p>{{#t}}pages.confirmation.content{{/t}}</p>
+
+{{/content}}
+
+{{/layout}}

--- a/config.js
+++ b/config.js
@@ -49,6 +49,10 @@ module.exports = {
     verify: {
       method: 'POST',
       endpoint: 'verify/evw'
+    },
+    check: {
+      method: 'GET',
+      endpoint: 'check/evw'
     }
   }
 };


### PR DESCRIPTION
#### Check number/token against integration stub 🔍 
- uses the same endpoint as for download verifcation, this may be incorrect, will need to catch up with @jackmaloney
- Use query string to pass number/token:
  - Params was too confusing with the way that the hmpo wizard wants to handle things
- Now we'll check for the presence of evwNum/token and set to session
- Session checks will occur in the entry url only as subsequent routes will redirect if there's no session established
- TODO tests for query/session checking

#### Adds stub confirmation page
