### PR TITLE
[NIJ] Add update-journey-details smoke test 🚭

### DIFF
--- a/acceptance_tests/features/smoke/update-journey-details.smoke.feature
+++ b/acceptance_tests/features/smoke/update-journey-details.smoke.feature
@@ -1,6 +1,9 @@
 @update_journey_smoke
 Feature: Updating Journey Details Smoke Test
 
+Background: Adding a canned case
+  Given I add a canned case
+
 Scenario: Entering new flight details and correct flight found
 
   Given I start the Update journey details app with smoke params

--- a/acceptance_tests/features/smoke/update-journey-details.smoke.feature
+++ b/acceptance_tests/features/smoke/update-journey-details.smoke.feature
@@ -1,0 +1,70 @@
+@update_journey_smoke
+Feature: Updating Journey Details Smoke Test
+
+Scenario: Entering new flight details and correct flight found
+
+  Given I start the Update journey details app with smoke params
+  Then the page title should contain "Your new journey to the UK"
+  When I click "By plane"
+  And I continue
+  Then I should be on the "Flight number" page of the "Update journey details" app
+  And the page title should contain "Your new flight details"
+  Then I enter "EK0009" into "Flight number"
+  And I continue
+  # Arrival date page
+  Then I should be on the "Arrival date" page of the "Update journey details" app
+  And the page title should contain "Your new flight details"
+  And I enter a date "2 months" in the future into "Arrival date"
+  And I continue
+  # Is this your flight page
+  Then I should be on the "Is this your flight" page of the "Update journey details" app
+  And the page title should contain "Is this your flight to the UK?"
+  And the "Flight number" should contain "EK0009"
+  And the "Departure airport" should contain "Dubai"
+  And the "Arrival airport" should contain "London - Gatwick"
+  # And the "Arrival date" should contain a date "2 months" in the future
+  And the "Arrival time" should contain "19:45"
+  And I click "Yes"
+  And I continue
+  # Departure date and time page
+  Then I should be on the "Departure date and time" page of the "Update journey details" app
+  And the page title should contain "Your journey to the UK"
+  And I enter a date "2 months" in the future into "Departure date"
+  And I enter the time "12:15" into "Departure time"
+  And I continue
+  # Check your answers page
+  Then the page title should contain "Check your answers"
+  And the summary table should contain
+
+    """
+    Departure airport
+                      Dubai
+    Departure date
+
+    Departure time
+                      12:15
+    Flight number
+                      EK0009
+    Arrival airport
+                      London - Gatwick
+    Arrival date
+
+    Arrival time
+                      19:45
+    """
+  And I continue
+  # Declaration page
+  Then I should be on the "Declaration" page of the "Update journey details" app
+  And the page title should contain "Declaration"
+  And the content list should contain
+    """
+    The new flight information I have entered is correct to the best of my knowledge and belief and is for my flight that lands in the UK.
+    On changing my flight details my old electronic visa waiver document will be invalid and I will not use it to try to enter the UK; if I do so I may be denied boarding or be refused entry at the UK border.
+    If I have completed this for someone else I have their full agreement.
+    """
+  When I click id "Accept Declaration"
+  And I continue
+  Then I should be on the "Confirmation" page of the "Update journey details" app
+  And the page title should contain "Electronic visa wavier"
+  And the "header notice complete" should contain "Request received"
+  And the reference number should be present

--- a/acceptance_tests/features/step_definitions/confirmation.js
+++ b/acceptance_tests/features/step_definitions/confirmation.js
@@ -4,9 +4,9 @@ module.exports = function () {
 
     this.Then(/^the reference number should be present$/, function () {
         this.getText('.header-notice-complete #referenceId', function (ref) {
-          this.assert.equal(ref.value.length, 8);
+          let referenceThere = ref.value.length > 7;
+          this.assert.equal(referenceThere, true);
         });
     });
 
 };
-

--- a/acceptance_tests/features/step_definitions/update-journey-smoke.js
+++ b/acceptance_tests/features/step_definitions/update-journey-smoke.js
@@ -2,7 +2,9 @@
 
 const config = require('../../../config');
 const moment = require('moment');
-const base = config.baseUrl || 'http://localhost:8080'; // TODO pull from config
+const base = config.baseUrl || 'http://localhost';
+const port = config.port || '8080';
+const request = require('request');
 
 const urlise = (text) => text.toLowerCase().replace(/[^\w ]+/g, '').replace(/ +/g, '-');
 
@@ -13,10 +15,33 @@ const futureDate = (future) => {
     return moment().add(amount, unit);
 }
 
+const fixture = {"objectId":"56ec2057084d726f6a4611b8","passport":{"givenNames":"Ahmed","surname":"Shehab Malbas Abdulla Alobeidli","passportNumber":"12345678Y","expiryDate":"2018-04-27","issueDate":"2013-04-28","placeOfIssue":"Kuwait","gender":"F","dateOfBirth":"1987-08-12","placeOfBirth":"KUWAIT","countryOfBirth":"KWT","nationality":"ARE","holdOtherNationalities":"No","heldPreviousNationalities":"No"},"payment":{"orderCode":"Free","feeInPence":0,"paid":true,"paymentDate":"2016-03-18 15:35:51"},"contactDetails":{"emailAddress":"test@gmail.com","secondEmail":"testing@gmail.com","homeAddress":["My House","STREET 32","HOUSE NUMBER 16","","KWT","00000"],"mobilePhoneNumber":"+123-99028325","phoneNumber":"+123-44422555","countryAppliedFrom":"Kuwait","countryAppliedFromCode":"KWT","areYouEmployed":"No"},"journey":{"travelBy":"Plane","arrivalTravel":"BA0156","arrivalDate":"2016-08-21","departureForUKDate":"2016-04-30 08:20:00","arrivalTime":"12:15","portOfArrival":"London - Heathrow","portOfArrivalCode":"LHR","ukAddress":["The hotel in London","Westminster, London W1 7YT,","","","W1 7YT"],"departureDate":"2016-04-21","departureTravel":"BA157","portOfDeparture" : "London - Heathrow, LHR","inwardDepartureCountry":"KWT","inwardDeparturePort":"Kuwait - Kuwait Intl","inwardDeparturePortCode":"KWI","reasonForTravel":"Tourism","travelWithOthers":"No","knowDepartureDetails":"Yes","ukVisitPhoneNumber":"+12345234234","visitMoreThanOnce":"No"},"miscellaneous":{"onBehalfOfMinor":"No","asAnAgent":"No", "flightDetailsCheck":"Yes"},"passportFileId":"56ec1bd8aee7c384447463f0","applicationReference":"EVW123456"};
+
 module.exports = function () {
 
+    this.Given(/^I add a canned case$/, function (callback) {
+        request.post({
+          url: `${base}:9300/tester/canned-evw-case/CHECK_ACCEPTED`,
+          json: fixture,
+          headers: {
+              'Content-Type': 'application/json'
+          }
+        }, function (err, response, body) {
+
+          if (err) {
+            console.log('error sending canned case', err, body);
+            return callback(err);
+          }
+          // TODO make nightwatch return passing assertion
+          // this.assert.ok(body.length);
+          callback('case added', body);
+        });
+
+    });
+
+
     this.Given(/^I start the Update journey details app with smoke params$/, function () {
-        this.url(`${base}/update-journey-details/how-will-you-arrive?evwNumber=EVW123456&token=74d3e5a47154150525964d90d0a99138a2633b49fbd9f829f9387414c1a458ef`)
+        this.url(`${base}:${port}/update-journey-details/how-will-you-arrive?evwNumber=EVW123456&token=74d3e5a47154150525964d90d0a99138a2633b49fbd9f829f9387414c1a458ef`)
         .waitForElementVisible('body', 1000);
     });
 

--- a/acceptance_tests/features/step_definitions/update-journey-smoke.js
+++ b/acceptance_tests/features/step_definitions/update-journey-smoke.js
@@ -39,7 +39,6 @@ module.exports = function () {
 
     });
 
-
     this.Given(/^I start the Update journey details app with smoke params$/, function () {
         this.url(`${base}:${port}/update-journey-details/how-will-you-arrive?evwNumber=EVW123456&token=74d3e5a47154150525964d90d0a99138a2633b49fbd9f829f9387414c1a458ef`)
         .waitForElementVisible('body', 1000);

--- a/acceptance_tests/features/step_definitions/update-journey-smoke.js
+++ b/acceptance_tests/features/step_definitions/update-journey-smoke.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const config = require('../../../config');
+const moment = require('moment');
+const base = config.baseUrl || 'http://localhost:8080'; // TODO pull from config
+
+const urlise = (text) => text.toLowerCase().replace(/[^\w ]+/g, '').replace(/ +/g, '-');
+
+const futureDate = (future) => {
+    let times = future.split(' ');
+    let amount = Number(times[0]);
+    let unit = times[1].slice(0,-1); //day/s month/s
+    return moment().add(amount, unit);
+}
+
+module.exports = function () {
+
+    this.Given(/^I start the Update journey details app with smoke params$/, function () {
+        this.url(`${base}/update-journey-details/how-will-you-arrive?evwNumber=EVW123456&token=74d3e5a47154150525964d90d0a99138a2633b49fbd9f829f9387414c1a458ef`)
+        .waitForElementVisible('body', 1000);
+    });
+
+    this.Then(/^I enter a date "([^"]*)" in the future into "([^"]*)"$/, function (future, field) {
+        let val = futureDate(future);
+        let target = urlise(field);
+
+        this.setValue('#' + target + '-day', val.day());
+        this.setValue('#' + target + '-month', val.month());
+        this.setValue('#' + target + '-year', val.year());
+    });
+
+    // this.Then(/^the "([^"]*)" should contain a date "([^"]*)" in the future$/, function (field, future) {
+    //     let val = futureDate(future);
+    //     let target = urlise(field);
+    //     this.assert.containsText('#' + target + '-day', val.day());
+    //     this.assert.containsText('#' + target + '-month', val.month());
+    //     this.assert.containsText('#' + target + '-year', val.year());
+    // });
+
+}

--- a/apps/common/views/error.html
+++ b/apps/common/views/error.html
@@ -9,6 +9,8 @@
     <a href="/{{startLink}}" class="button" role="button">Start again</a>
     {{#showStack}}
       <pre>
+        {{error}}
+        {{error.message}}
         {{error.stack}}
       </pre>
     {{/showStack}}

--- a/apps/find-your-application/controllers/enter-your-details.js
+++ b/apps/find-your-application/controllers/enter-your-details.js
@@ -18,11 +18,13 @@ module.exports = class EnterYourDetailsController extends EvwBaseController {
 
     lookup.find(values.evwNumber, values.dateOfBirth).then((response) => {
       let result = response.body;
+      logger.info('application lookup result', response.body);
 
       // Application not found / too late
       if (result.error) {
         req.sessionModel.set('evwLookupError', result.error);
       }
+
       super.process(req, res, callback);
     },
     (err) => logger.error(err));

--- a/apps/update-journey-details/controllers/arrival-date.js
+++ b/apps/update-journey-details/controllers/arrival-date.js
@@ -3,6 +3,7 @@
 const util = require('util');
 const EvwBaseController = require('../../common/controllers/evw-base');
 const flightLookup = require('../../../lib/flight-lookup');
+const logger = require('../../../lib/logger');
 
 const ArrivalDateController = function ArrivalDateController() {
   EvwBaseController.apply(this, arguments);
@@ -18,7 +19,10 @@ ArrivalDateController.prototype.saveValues = function saveValues(req, res, callb
         arrivalDateYear: req.form.values['arrival-date-year']
     });
 
+    logger.info('looking up flight', lookupData);
+
     flightLookup.findFlight(lookupData.number, lookupData.date).then(function (foundData) {
+        logger.info('flight service response for', lookupData, foundData.body);
         let flight = foundData.body.flights[0];
 
         // Flight found

--- a/apps/update-journey-details/controllers/confirmation.js
+++ b/apps/update-journey-details/controllers/confirmation.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const moment = require('moment');
 const EvwBaseController = require('../../common/controllers/evw-base');
 const is = require('../../../config').integrationService;
 const request = require('request');
@@ -20,7 +21,9 @@ const propMap = (model) => {
     portOfArrivalCode: f.portOfArrivalPlaneCode,
     inwardDepartureCountry: f.inwardDepartureCountryPlaneCode,
     inwardDeparturePort: f.departureAirport,
-    inwardDeparturePortCode: f.inwardDeparturePortPlaneCode
+    inwardDeparturePortCode: f.inwardDeparturePortPlaneCode,
+    dateCreated: moment().format('YYYY-MM-DD hh:mm:ss'),
+    flightDetailsCheck: 'Yes' // hard-coded until we implement un-happy path
   }
 };
 
@@ -46,14 +49,12 @@ class ConfirmationController extends EvwBaseController {
     }, function (err, response, body) {
 
       if (err) {
-        req.sessionModel.reset();
         logger.error('error sending update to integration service', err);
         return callback(err);
       }
 
       if (body.error) {
-        req.sessionModel.reset();
-        logger.error('error sending update to integration service', body.error);
+        logger.error('body error sending update to integration service', body.error || err);
         return callback(body.error);
         /* eslint no-warning-comments: 1*/
         // TODO change to an error page

--- a/apps/update-journey-details/controllers/how-will-you-arrive.js
+++ b/apps/update-journey-details/controllers/how-will-you-arrive.js
@@ -62,7 +62,9 @@ const validateApp = (req, res, callback) => {
       /* eslint no-warning-comments: 1*/
       // TODO change to a invalid page
     }
-
+    let startLink = req.path.replace(/^\/([^\/]*).*$/, '$1') + `?evwNumber=${evwNumber}&token=${token}`;
+    logger.info('setting startLink', startLink);
+    req.sessionModel.set('startLink', startLink);
     req.sessionModel.set('validated', true);
     req.sessionModel.set('evw-number', evwNumber);
     req.sessionModel.set('token', token);

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -107,7 +107,6 @@
   },
   "confirmation": {
     "header": "Electronic visa wavier",
-    "header": "Electronic Visa Wavier",
     "received": "Request received",
     "reference": "Your reference is",
     "email": "We will email",

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -107,6 +107,7 @@
   },
   "confirmation": {
     "header": "Electronic visa wavier",
+    "header": "Electronic Visa Wavier",
     "received": "Request received",
     "reference": "Your reference is",
     "email": "We will email",

--- a/config.js
+++ b/config.js
@@ -56,7 +56,7 @@ module.exports = {
     },
     check: {
       method: 'GET',
-      endpoint: 'check/evw'
+      endpoint: 'check/update'
     },
     update: {
       method: 'POST',

--- a/config.js
+++ b/config.js
@@ -3,9 +3,13 @@
 /*eslint no-process-env: 0*/
 /*eslint no-inline-comments: 0*/
 /*eslint camelcase: 0*/
+
+let port = process.env.PORT || 8080;
+
 module.exports = {
   env: process.env.NODE_ENV,
-  port: process.env.PORT || 8080,
+  port: port,
+  baseUrl: process.env.BASE_URL || 'http://localhost:' + port,
   listen_host: process.env.LISTEN_HOST || '0.0.0.0',
   assetPath: process.env.ASSET_PATH || '/public',
   govukAssetPath: process.env.GOVUK_ASSET_PATH || '/govuk-assets',

--- a/config.js
+++ b/config.js
@@ -9,7 +9,7 @@ let port = process.env.PORT || 8080;
 module.exports = {
   env: process.env.NODE_ENV,
   port: port,
-  baseUrl: process.env.BASE_URL || 'http://localhost:' + port,
+  baseUrl: process.env.BASE_URL || 'http://localhost',
   listen_host: process.env.LISTEN_HOST || '0.0.0.0',
   assetPath: process.env.ASSET_PATH || '/public',
   govukAssetPath: process.env.GOVUK_ASSET_PATH || '/govuk-assets',

--- a/errors/index.js
+++ b/errors/index.js
@@ -23,17 +23,25 @@ module.exports = function errorHandler(err, req, res, next) {
     content.message = i18n.translate('errors.cookies-required.message');
   }
 
-  err.template = 'error';
+  let error = {
+    message: err,
+    template: 'error'
+  };
+  let startLink = req.sessionModel.get('startLink');
+  req.sessionModel.reset();
   content.title = content.title || i18n.translate('errors.default.title');
   content.message = content.message || i18n.translate('errors.default.message');
 
   res.statusCode = err.status || 500;
 
-  logger.error(err.message || err.error, err);
-  res.render(err.template, {
-    error: err,
+  logger.error(err);
+  res.render(error.template, {
+    error: error.message,
     content: content,
     showStack: (config.env === 'development' || config.env === 'docker-compose'),
-    startLink: req.path.replace(/^\/([^\/]*).*$/, '$1')
+    startLink: startLink ? [
+      req.path.replace(/^\/([^\/]*).*$/, '$1'),
+      startLink
+    ].join('/') : req.path.replace(/^\/([^\/]*).*$/, '$1')
   });
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "watch:js": "nodemon --watch assets/js -x 'npm run browserify'",
     "watch:translations": "nodemon --watch apps/update-journey-details/translations/src -x 'npm run hof-transpile'",
     "test": "NODE_ENV=test node_modules/.bin/mocha",
-    "test:acceptance": "node_modules/.bin/nightwatch -e default",
+    "test:acceptance": "node_modules/.bin/nightwatch -e default --skiptags update_journey_smoke",
     "test:ci": "npm run lint && npm run test",
     "browserify": "browserify ./assets/js/index.js > ./public/js/bundle.js",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eslint-plugin-filenames": "^1.0.0",
     "eslint-plugin-mocha": "^3.0.0",
     "eslint-plugin-one-variable-per-var": "0.0.3",
-    "evw-integration-stub": "^1.1.5",
+    "evw-integration-stub": "^1.1.7",
     "hof-transpiler": "0.0.6",
     "jscs": "^3.0.4",
     "mocha": "^2.2.5",

--- a/test/apps/update-journey-details/controllers/confirmation.spec.js
+++ b/test/apps/update-journey-details/controllers/confirmation.spec.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const moment = require('moment');
 let ConirmationController = require('../../../../apps/update-journey-details/controllers/confirmation');
 let propMap = ConirmationController.propMap;
 let modelFixture = require('../../../fixtures/update-model');
@@ -16,6 +17,8 @@ describe('apps/update-journey-details/controllers/confirmation', function () {
         'arrivalTime' : '19:45',
         'departureForUKDate' : '2016-10-10',
         'departureForUKTime' : '01:01',
+        'flightDetailsCheck': 'Yes',
+        'dateCreated': moment().format('YYYY-MM-DD hh:mm:ss'),
         'portOfArrival' : 'London - Gatwick',
         'portOfArrivalCode' : 'LGW',
         'inwardDepartureCountry': 'ARE',


### PR DESCRIPTION
#### Add in confirmation page 
- Updates `evw-integration-stub` to latest to pick up `update` endpoint
- Sends mapped subset of user information to integration service using `propMap`
- Quick test for propMap
- adds email address and reference number brought back from integration service
- Calls to integration service but does not save to customer db yet
- adds small amount of additional styling to render teal confirmation box

#### Add acceptance test for confirmation page 
- Checks for the presence of confirmation number (of fixed length, but allows it to be any string of length === 8)
- `emailAddress` and `updateNumber` now added to the `req` so we can manually clear the session (as per issue noted here: https://github.com/UKHomeOffice/global-entry-customer/blob/master/apps/global-entry/controllers/complete.js#L22-L30)

#### Add a custom startLink to re-include query string 
- If we get an error in the app the user was being redirected back to the root without any query string, thus chucking them out of the app indefinitely. This fixes that by adding the query to the start link in the session, which will get cleared at the end of the application process

#### check/evw => check/update 
- this has changed in `evw-integration-service`

#### Smoke tests should be ignored in CI 