### PR TITLE
EVW-1442 No validation on departure date

### DIFF
--- a/apps/update-journey-details/fields/arrival-date.js
+++ b/apps/update-journey-details/fields/arrival-date.js
@@ -2,6 +2,8 @@
 
 module.exports = {
   'arrival-date': {
+    type: ['date'],
+    validate: [] // blank because dates are being 'future' validated by default
   },
   'arrival-date-day': {
       validate: ['required', 'numeric'],

--- a/validation/departure-time.js
+++ b/validation/departure-time.js
@@ -10,7 +10,7 @@ module.exports = {
     // We allow time travel of one hour max to compensate for time-zone hopping
     // `departure-time: 8:00` => `arrival-time: 7:00` is okay
     // `departure-time: 8:10` => `arrival-time: 7:00` is not
-    if (moment(arrivalDateTime).isBefore(moment(departureDateTime).subtract(1, 'hour'))) {
+    if (arrivalDateTime.isBefore(departureDateTime.subtract(1, 'hour'))) {
       return {
         length: {
           minimum: 12,
@@ -19,7 +19,7 @@ module.exports = {
       };
     }
 
-    if (moment(departureDateTime).isBefore(moment(arrivalDateTime).subtract(24, 'hours'))) {
+    if (departureDateTime.isBefore(arrivalDateTime.subtract(24, 'hours'))) {
       return {
         length: {
           minimum: 12,


### PR DESCRIPTION
Set `arrival-date` to have `type: ['date']` so it is treated as a HOF date and saved in the model correctly. The departure date and time fields will then be validated with the arrival date properly.

Simplified the departure date and time validation by removing some of the `moment` objects.