### PR TITLE
EVW-1472 Check your email page add email address

### DIFF
--- a/acceptance_tests/features/find-your-application.feature
+++ b/acceptance_tests/features/find-your-application.feature
@@ -10,7 +10,7 @@ Scenario: Requesting a flight change link
   # Link sent page
   Then I should be on the "Link sent" page of the "Find your application" app
   Then the page title should contain "Check your email"
-  And the page content should contain "We have emailed you with a link for you to change your flight details."
+  And the page content should contain "We have sent a link for you to change your flight details to"
 
 Scenario: Application not yet verified
   Given I start the "Find your application" app

--- a/apps/find-your-application/controllers/enter-your-details.js
+++ b/apps/find-your-application/controllers/enter-your-details.js
@@ -21,8 +21,9 @@ module.exports = class EnterYourDetailsController extends EvwBaseController {
         let result = response.body;
         logger.info('application lookup result', response.body);
 
-        // Application not found / too late
-        if (result.error) {
+        if (result.emailAddress) {
+          req.sessionModel.set('emailAddress', result.emailAddress);
+        } else if (result.error) {
           req.sessionModel.set('evwLookupError', result.error);
         }
         callback();

--- a/apps/find-your-application/controllers/link-sent.js
+++ b/apps/find-your-application/controllers/link-sent.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const EvwBaseController = require('../../common/controllers/evw-base');
+
+module.exports = class LinkSentController extends EvwBaseController {
+
+  locals(req, res) {
+    return Object.assign({
+      emailAddress: req.sessionModel.get('emailAddress')
+    }, super.locals.call(this, req, res));
+  }
+}

--- a/apps/find-your-application/steps.js
+++ b/apps/find-your-application/steps.js
@@ -27,7 +27,8 @@ module.exports = {
     }]
   },
   '/link-sent': {
-    template: 'link-sent'
+    template: 'link-sent',
+    controller: require('./controllers/link-sent')
   },
   '/evw-expired': {
     template: 'evw-expired'

--- a/apps/find-your-application/translations/src/en/pages.json
+++ b/apps/find-your-application/translations/src/en/pages.json
@@ -55,7 +55,7 @@
   },
   "link-sent": {
     "header": "Check your email",
-    "content-1": "We have emailed you with a link for you to change your flight details.",
+    "content-1": "We have sent a link for you to change your flight details to",
     "content-2": "Check your spam or junk folder if you can't find the email in your inbox."
   },
   "enter-your-details": {

--- a/apps/find-your-application/views/link-sent.html
+++ b/apps/find-your-application/views/link-sent.html
@@ -16,7 +16,7 @@
 
 {{$content}}
 <h1 class="heading-large">{{#t}}pages.link-sent.header{{/t}}</h1>
-<p>{{#t}}pages.link-sent.content-1{{/t}}</p>
+<p>{{#t}}pages.link-sent.content-1{{/t}} {{emailAddress}}</p>
 <p>{{#t}}pages.link-sent.content-2{{/t}}</p>
 {{/content}}
 


### PR DESCRIPTION
The verify EVW successful response now contains the user's email address so we need to save it and display it on the `/link-sent` page.

![screen-shot-2016-07-27-at-14 29](https://cloud.githubusercontent.com/assets/6839214/17177051/65efeea0-5407-11e6-8857-019432ec3c9a.png)

