### PR TITLE
EVW-1477 Validation defect for journey update in 2 days time 

### DIFF
--- a/test/validation/arrival-date.spec.js
+++ b/test/validation/arrival-date.spec.js
@@ -14,7 +14,7 @@ describe('validation/arrival-date', function() {
   });
 
   it('should be less than 3 months in the future', function() {
-    validation.rules(moment().add(4, 'months')).should.deep.equal({
+    validation.rules(moment().add(4, 'months').format('DD-MM-YYYY')).should.deep.equal({
       length: {
         minimum: 12,
         message: 'arrival-date.too-far-in-future'
@@ -22,8 +22,8 @@ describe('validation/arrival-date', function() {
     });
   });
 
-  it('should me more than 48 hours in the future', function() {
-    validation.rules(moment().add(47, 'hours')).should.deep.equal({
+  it('should be more than 48 hours in the future', function() {
+    validation.rules(moment().add(1, 'day').format('DD-MM-YYYY')).should.deep.equal({
       length: {
         minimum: 12,
         message: 'arrival-date.within-48-hours'

--- a/validation/arrival-date.js
+++ b/validation/arrival-date.js
@@ -4,7 +4,7 @@ const moment = require('moment');
 
 module.exports = {
   rules: (fieldValue) => {
-    let date = moment(fieldValue, 'DD-MM-YYYY');
+    let date = moment(`${fieldValue} ${moment().format('HH:mm:ss')}`, 'DD-MM-YYYY HH:mm:ss');
     let threeMonths = moment().add(3, 'months');
     let fourtyEight = moment().add(48, 'hours');
 
@@ -17,7 +17,7 @@ module.exports = {
       };
     }
 
-    if (threeMonths.isBefore(date)) {
+    if (threeMonths.isBefore(date, 'second')) {
       return {
         length: {
           minimum: 12,
@@ -26,7 +26,7 @@ module.exports = {
       };
     }
 
-    if (fourtyEight.isAfter(date)) {
+    if (fourtyEight.isAfter(date, 'second')) {
       return {
         length: {
           minimum: 12,


### PR DESCRIPTION
Improve the check that the arrival date and time is not within 48 hours of the date and time now

- Add the current time to the arrival time so we can get a better comparison
- Change the comparison granularity from the default (milliseconds) to seconds
- Improve the unit tests so they pass a string into the validation rather than a moment object

Scenario...If an arrival date of 2 days time is entered for a flight which has an arrival time later than the time now then this is outside the 48 hour window and should be valid.

**Before**

![screen-shot-2016-07-28-at-11 40](https://cloud.githubusercontent.com/assets/6839214/17210225/3dd0ce6e-54b9-11e6-90e2-71dbe2b791f6.png)

**After**

![screen-shot-2016-07-28-at-11 41 59](https://cloud.githubusercontent.com/assets/6839214/17210229/46101332-54b9-11e6-9675-63dd4a1d2ab1.png)
