### PR TITLE
EVW-1478 No 'required' validation message for departure date

### DIFF
--- a/acceptance_tests/features/validation.feature
+++ b/acceptance_tests/features/validation.feature
@@ -44,3 +44,25 @@ Scenario: Entering an EVW number that cannot be updated
   # EVW expired page
   Then I should be on the "EVW expired" page of the "Find your application" app
   And the page title should contain "Electronic visa waiver expired"
+
+Scenario: Not entering any details on the departure date and time page
+
+  Given I start the Update journey details app
+  # How will you arrive page
+  When I click "By plane"
+  And I continue
+  And I enter "KU101" into "Flight number"
+  And I continue
+  # Arrival date page
+  And I enter the date "10-08-2016" into "Arrival date"
+  And I continue
+  # Is this your flight page
+  And I click "Yes"
+  And I continue
+  # Departure date and time page
+  And I continue
+  Then the validation summary should contain
+    """
+    Enter the date you will depart for the UK
+    Please enter a time
+    """

--- a/apps/update-journey-details/fields/departure-date-and-time.js
+++ b/apps/update-journey-details/fields/departure-date-and-time.js
@@ -2,8 +2,8 @@
 
 module.exports = {
   'departure-date': {
-    type: [ 'date' ],
-    validate: [] // blanked out validation because 'future was being applied for some wtf reason'
+    type: ['date'],
+    validate: ['required']
   },
   'departure-date-day': {
     validate: ['required', 'numeric'],
@@ -18,8 +18,8 @@ module.exports = {
     label: 'fields.departure-date-year.label'
   },
   'departure-time': {
-    validate: [ 'required' ],
-    type: [ 'time' ]
+    validate: ['required'],
+    type: ['time']
   },
   'departure-time-hours': {
     validate: ['required', 'numeric'],

--- a/apps/update-journey-details/translations/src/en/validation.json
+++ b/apps/update-journey-details/translations/src/en/validation.json
@@ -23,6 +23,7 @@
     "required": "Please indicate that you agree to the declaration"
   },
   "departure-date": {
+    "required": "Enter the date you will depart for the UK",
     "invalid": "Select a valid date you will depart for the UK",
     "in-past": "The date your flight to the UK takes off cannot be more than 1 day before it arrives in the UK",
     "in-future": "The date your flight to the UK takes off cannot be after the date it arrives in the UK"


### PR DESCRIPTION
The `departure-date` field is required and if the user tried to proceed without entering it then an error would show without a message. This adds the message.

**Before**

![screen-shot-2016-07-28-at-14 452](https://cloud.githubusercontent.com/assets/6839214/17215012/5b985cf4-54d3-11e6-94b9-9d2ada753d03.png)

**After**

![screen-shot-2016-07-28-at-14 45](https://cloud.githubusercontent.com/assets/6839214/17215027/676d85f4-54d3-11e6-8c7e-63026337af9d.png)
