### PR TITLE
EVW-1484 Ambiguous  error message is displayed when an invalid DOB is entered.

### DIFF
--- a/acceptance_tests/features/validation.feature
+++ b/acceptance_tests/features/validation.feature
@@ -9,7 +9,7 @@ Scenario: Wrong details in Enter Your Details
   And I continue
   Then the validation summary should contain
     """
-    Please enter numbers only
+    Please enter a valid date, for example, 22 3 1979
     Please enter your electronic visa waiver number
     """
 
@@ -24,7 +24,7 @@ Scenario: Entering an EVW number that is not found
     We can't find your EVW
     """
 
-Scenario: non-numeric dob
+Scenario: Entering a dob that is non-numeric
 
   Given I start the "Find your application" app
   When I enter "VALID1000" into "EVW number"
@@ -32,7 +32,7 @@ Scenario: non-numeric dob
   And I click confirm details
   Then the validation summary should contain
     """
-    Please enter numbers only
+    Please enter a valid date, for example, 22 3 1979
     """
 
 Scenario: Entering an EVW number that cannot be updated

--- a/apps/find-your-application/translations/src/en/validation.json
+++ b/apps/find-your-application/translations/src/en/validation.json
@@ -6,7 +6,7 @@
   },
   "dob": {
     "required": "Enter your date of birth",
-    "numeric": "Please enter numbers only",
+    "numeric": "Please enter a valid date, for example, 22 3 1979",
     "future": "Date of birth cannot be in the future",
     "format": "Please use the correct date format, for example, 22 3 1979",
     "date": "Please use the correct date format, for example, 22 3 1979"


### PR DESCRIPTION
**Change 'numeric' error message**

HOF currently treats the date 00-00-0000 as non-numeric so we need an error message that makes sense for both 12-!!-1987 and 00-00-0000.

**Before**

![screen-shot-2016-07-29-at-10 06](https://cloud.githubusercontent.com/assets/6839214/17243441/c03da03c-5574-11e6-8dc3-e1403481715e.png)

**After**

![screen-shot-2016-07-29-at-10 06 48](https://cloud.githubusercontent.com/assets/6839214/17243453/cab36fa6-5574-11e6-80e2-9a03a428ddd6.png)
