### PR TITLE
EVW-1515 Update flight details styling - new flight number page

### DIFF
--- a/apps/update-journey-details/translations/src/en/fields.json
+++ b/apps/update-journey-details/translations/src/en/fields.json
@@ -20,8 +20,7 @@
     }
   },
   "flight-number": {
-    "label": "New flight number",
-    "hint": "For example EK009, QR003 or KU101"
+    "label": "New flight number<p class='form-hint'>For example EK009, QR003 or KU101</p><p class='form-hint'>If you have any stops or connecting flights you must enter the number for the final part of your journey to the UK</p>"
   },
   "arrival-date": {
     "legend": "New date of arrival in the UK",

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -49,7 +49,6 @@
   "flight-number": {
     "header": "Your new flight details",
     "question": "New flight number",
-    "call-out": "If you have any stops or connecting flights you must enter the number for the final part of your journey to the UK",
     "help-text-title": "What is my flight number?",
     "help-text-content-1": "A flight number has 2 or 3 letters or numbers representing the airline followed by 1 to 4 numbers and sometimes an extra letter at the end, for example EK009, QR003 or KU101. It is not the same as the booking confirmation from your travel agent or airline.",
     "help-text-content-2": "If you are taking more than 1 flight to reach the UK we only need to know the number for the flight that lands in the UK."

--- a/apps/update-journey-details/views/flight-number.html
+++ b/apps/update-journey-details/views/flight-number.html
@@ -17,29 +17,25 @@
     <h1 class="heading-large">{{#t}}pages.flight-number.header{{/t}}</h1>
 </header>
 
-<div class="panel panel-border-wide">
-    {{#t}}pages.flight-number.call-out{{/t}}
-</div>
-
 {{<partials-form}}
 
 {{$form}}
 
 {{#input-text}}flight-number{{/input-text}}
 
-{{#input-submit}}continue{{/input-submit}}
-
-{{/form}}
-
-{{/partials-form}}
-
-<details>
+<details class="flight-number-panel">
   <summary><span class="summary">{{#t}}pages.flight-number.help-text-title{{/t}}</span></summary>
   <div class="panel panel-border-narrow">
     <p>{{#t}}pages.flight-number.help-text-content-1{{/t}}</p>
     <p>{{#t}}pages.flight-number.help-text-content-2{{/t}}</p>
   </div>
 </details>
+
+{{#input-submit}}continue{{/input-submit}}
+
+{{/form}}
+
+{{/partials-form}}
 
 {{/content}}
 

--- a/assets/scss/_hof_overrides.scss
+++ b/assets/scss/_hof_overrides.scss
@@ -22,5 +22,6 @@
 }
 
 .form-group .form-hint {
-  @include bold-19;
+  color: $black;
+  @include core-19;
 }

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -72,7 +72,7 @@ h1 {
 
 //custom form styling
 .form-control {
-  padding: 0.5em;
+  border: 2px solid #6f777b;
 
   @include media(desktop) {
     width: 65%;

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -134,3 +134,7 @@ h1 {
     @include core-19();
   }
 }
+
+#flight-number {
+  width: 110px;
+}

--- a/assets/scss/panels.scss
+++ b/assets/scss/panels.scss
@@ -64,3 +64,7 @@
   margin-top: 10px;
   margin-bottom: 0;
 }
+
+.flight-number-panel {
+  padding-bottom: 20px;
+}


### PR DESCRIPTION
- Form hint styling
 - Not bold
 - Black
- Form control styling
 - Darker grey
 - Thicker border width
 - Change padding back to default
- Flight number page styling
 - Removed the call-out text and added as a form hint
 - Two form hints needed so added html into the label instead of using default form hint
 - Moved the help panel above the submit button
 - Increased the gap between the help panel and the submit button
 - Decreased the width of the flight number field

**Before**

![flight-number-before](https://cloud.githubusercontent.com/assets/6839214/17361012/1ead2c60-5966-11e6-9a1c-f9512cc7543f.png)

**After**

![flight-number-after2](https://cloud.githubusercontent.com/assets/6839214/17363138/a621a310-5970-11e6-88d0-dded7a5a207d.png)

