### PR TITLE
EVW-1531 Self serve Date time arrival validation

### DIFF
--- a/apps/update-journey-details/controllers/arrival-date.js
+++ b/apps/update-journey-details/controllers/arrival-date.js
@@ -11,8 +11,8 @@ module.exports = class ArrivalDateController extends EvwBaseController {
     super.applyDatesTimes(options.fields);
   }
 
-  saveValues(req, res, callback) {
-    super.saveValues(req, res, () => {
+  process(req, res, callback) {
+    super.process(req, res, () => {
       let lookupData = flightLookup.formatPost({
         flightNumber: req.sessionModel.get('flight-number'),
         arrivalDateDay: req.form.values['arrival-date-day'],
@@ -22,7 +22,7 @@ module.exports = class ArrivalDateController extends EvwBaseController {
 
       logger.info('looking up flight', lookupData);
 
-      flightLookup.findFlight(lookupData.number, lookupData.date).then(function (foundData) {
+      flightLookup.findFlight(lookupData.number, lookupData.date).then((foundData) => {
         logger.info('flight service response for', lookupData, foundData.body);
         let flight = foundData.body.flights[0];
 

--- a/test/lib/flight-lookup.spec.js
+++ b/test/lib/flight-lookup.spec.js
@@ -1,17 +1,17 @@
 'use strict';
 
 const path = require('path');
-let flightLookup = require('../../../../lib/flight-lookup');
-let airports = require('../../../../data/airports');
+let flightLookup = require('../../lib/flight-lookup');
+let airports = require('../../data/airports');
 let chaiAsPromised = require('chai-as-promised');
-let config = require('../../../../config');
+let config = require('../../config');
 chai.use(chaiAsPromised);
 
 describe('lib/flight-lookup', function() {
 
     before(function (done) {
         let port = config.flightService.url.split(':').pop();
-        let dir = path.resolve(__dirname, '../../../../mocks');
+        let dir = path.resolve(__dirname, '../../mocks');
         this.dyson = dysonServer({
           mocks: dir,
           port: port,

--- a/test/validation/arrival-date.spec.js
+++ b/test/validation/arrival-date.spec.js
@@ -4,8 +4,19 @@ const validation = require('../../validation/arrival-date');
 const moment = require('moment');
 
 describe('validation/arrival-date', function() {
+  let model = {
+    get: function (key) {
+      return this.attributes[key];
+    },
+    attributes: {
+      flightDetails: {
+        arrivalTime: '12:23'
+      }
+    }
+  };
+
   it('should be a valid date', function() {
-    validation.rules('32-08-2016').should.deep.equal({
+    validation.rules('32-08-2016', model).should.deep.equal({
       length: {
         minimum: 12,
         message: 'arrival-date.invalid'
@@ -14,7 +25,7 @@ describe('validation/arrival-date', function() {
   });
 
   it('should be less than 3 months in the future', function() {
-    validation.rules(moment().add(4, 'months').format('DD-MM-YYYY')).should.deep.equal({
+    validation.rules(moment().add(4, 'months').format('DD-MM-YYYY'), model).should.deep.equal({
       length: {
         minimum: 12,
         message: 'arrival-date.too-far-in-future'
@@ -23,7 +34,7 @@ describe('validation/arrival-date', function() {
   });
 
   it('should be more than 48 hours in the future', function() {
-    validation.rules(moment().add(1, 'day').format('DD-MM-YYYY')).should.deep.equal({
+    validation.rules(moment().add(1, 'day').format('DD-MM-YYYY'), model).should.deep.equal({
       length: {
         minimum: 12,
         message: 'arrival-date.within-48-hours'

--- a/validation/arrival-date.js
+++ b/validation/arrival-date.js
@@ -3,8 +3,8 @@
 const moment = require('moment');
 
 module.exports = {
-  rules: (fieldValue) => {
-    let date = moment(`${fieldValue} ${moment().format('HH:mm:ss')}`, 'DD-MM-YYYY HH:mm:ss');
+  rules: (fieldValue, model) => {
+    let date = moment(`${fieldValue} ${model.get('flightDetails').arrivalTime}:00`, 'DD-MM-YYYY HH:mm:ss');
     let threeMonths = moment().add(3, 'months');
     let fourtyEight = moment().add(48, 'hours');
 


### PR DESCRIPTION
- Use the arrival time in the validator instead of the current time
- Use process function instead of saveValues function to get flight details earlier in the stack so we can validate using the arrival time
- Change unit tests to mock the model
- Minor formatting improvements
- Move the flight-lookup unit tests into the correct directory