### PR TITLE
Feature/evw 1421 swap redis to mongo connector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - '4'
 services:
-- redis-server
+- mongodb
 cache:
   directories:
   - node_modules

--- a/app.js
+++ b/app.js
@@ -63,7 +63,7 @@ app.use(require('cookie-parser')(config.session.secret));
 app.use(secureCookies);
 
 // Mongo session
-const mongoSession = require('./lib/session/mongo.js')(config);
+const mongoSession = require('./lib/session/mongo')(config);
 app.use(mongoSession);
 
 app.get('/cookies', function renderCookies(req, res) {

--- a/app.js
+++ b/app.js
@@ -5,7 +5,6 @@ var app = express();
 var path = require('path');
 var logger = require('./lib/logger');
 var churchill = require('churchill');
-var session = require('express-session');
 
 var config = require('./config');
 require('moment-business');
@@ -48,35 +47,6 @@ app.use(function setBaseUrl(req, res, next) {
 // Trust proxy for secure cookies
 app.set('trust proxy', 1);
 
-/*************************************/
-/******* Redis session storage *******/
-/*************************************/
-var redis = require('redis');
-var RedisStore = require('connect-redis')(session);
-var client = redis.createClient(config.redis.port, config.redis.host);
-
-client.on('connecting', function redisConnecting() {
-  logger.info('Connecting to redis');
-});
-
-client.on('connect', function redisConnected() {
-  logger.info('Connected to redis');
-});
-
-client.on('reconnecting', function redisReconnecting() {
-  logger.info('Reconnecting to redis');
-});
-
-client.on('error', function clientErrorHandler(e) {
-  logger.error(e);
-});
-
-var redisStore = new RedisStore({
-  client: client,
-  ttl: config.session.ttl,
-  secret: config.session.secret
-});
-
 function secureCookies(req, res, next) {
   var cookie = res.cookie.bind(res);
   res.cookie = function cookieHandler(name, value, options) {
@@ -91,16 +61,10 @@ function secureCookies(req, res, next) {
 
 app.use(require('cookie-parser')(config.session.secret));
 app.use(secureCookies);
-app.use(session({
-  store: redisStore,
-  cookie: {
-    secure: (config.env === 'development' || config.env === 'ci' || config.env === 'docker-compose') ? false : true
-  },
-  key: 'evw-self-serve.sid',
-  secret: config.session.secret,
-  resave: true,
-  saveUninitialized: true
-}));
+
+// Mongo session
+const mongoSession = require('./lib/session/mongo.js')(config);
+app.use(mongoSession);
 
 app.get('/cookies', function renderCookies(req, res) {
   res.render('cookies');

--- a/config.js
+++ b/config.js
@@ -19,9 +19,9 @@ module.exports = {
     secret: process.env.SESSION_SECRET || 'howdoesyourgardengrow',
     ttl: process.env.SESSION_TTL || 1200 /* 20 mins */
   },
-  redis: {
-    port: process.env.REDIS_PORT_6379_TCP_PORT || process.env.REDIS_PORT || 6379,
-    host: process.env.REDIS_PORT_6379_TCP_ADDR || process.env.REDIS_HOST || '127.0.0.1'
+  mongo: {
+    connectionString: process.env.MONGO_CONNECTION_STRING || 'mongodb://localhost:27017/evw-self-serve',
+    secret: process.env.SESSION_SECRET || 'thisisnotasecurepassword'
   },
   flightService: {
     url: process.env.FLIGHT_SERVICE_URL || 'http://localhost:9350',

--- a/config.js
+++ b/config.js
@@ -20,8 +20,7 @@ module.exports = {
     ttl: process.env.SESSION_TTL || 1200 /* 20 mins */
   },
   mongo: {
-    connectionString: process.env.MONGO_CONNECTION_STRING || 'mongodb://localhost:27017/evw-self-serve',
-    secret: process.env.SESSION_SECRET || 'thisisnotasecurepassword'
+    connectionString: process.env.MONGO_CONNECTION_STRING || 'mongodb://localhost:27017/evw-self-serve'
   },
   flightService: {
     url: process.env.FLIGHT_SERVICE_URL || 'http://localhost:9350',

--- a/lib/session/mongo.js
+++ b/lib/session/mongo.js
@@ -7,6 +7,12 @@ module.exports = (config) => {
     ttl: config.session.ttl,
     resave: true,
     saveUninitialized: true,
+    cookie: {
+      secure: (
+        config.env === 'development' ||
+        config.env === 'ci' ||
+        config.env === 'docker-compose') ? false : true
+    },
     store: new MongoStore({
       url: config.mongo.connectionString,
     })

--- a/lib/session/mongo.js
+++ b/lib/session/mongo.js
@@ -1,0 +1,14 @@
+const session = require('express-session');
+const MongoStore = require('connect-mongo')(session);
+
+module.exports = (config) => {
+  return session({
+    secret: config.session.secret,
+    ttl: config.session.ttl,
+    resave: true,
+    saveUninitialized: true,
+    store: new MongoStore({
+      url: config.mongo.connectionString,
+    })
+  });
+};

--- a/lib/session/mongo.js
+++ b/lib/session/mongo.js
@@ -10,8 +10,8 @@ module.exports = (config) => {
     cookie: {
       secure: (
         config.env === 'development' ||
-        config.env === 'ci' ||
-        config.env === 'docker-compose') ? false : true
+        config.env === 'ci'
+      ) ? false : true
     },
     store: new MongoStore({
       url: config.mongo.connectionString,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "browserify": "^13.0.1",
     "characteristic": "0.0.3",
     "churchill": "0.0.5",
+    "connect-mongo": "^1.3.2",
     "connect-redis": "^3.0.2",
     "cookie-parser": "^1.3.5",
     "express": "^4.12.4",

--- a/test/lib/session/mongo.spec.js
+++ b/test/lib/session/mongo.spec.js
@@ -13,9 +13,6 @@ const mockConfig = {
   }
 };
 
-// let fakeExpressSession = () => {
-//   sessionObject: true
-// };
 let sessionStub = sinon.stub();
 let mongoStoreStub = sinon.stub();
 let mongoSession;

--- a/test/lib/session/mongo.spec.js
+++ b/test/lib/session/mongo.spec.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const proxyquire = require('proxyquire').noPreserveCache();
+const mockConfig = {
+  session: {
+    secret: 'ohsosecret',
+    ttl: 5000
+  },
+  mongo: {
+    port: 27017,
+    host: 'localhost',
+    connectionString: 'mongodb://notarealdatabase:27016'
+  }
+};
+
+// let fakeExpressSession = () => {
+//   sessionObject: true
+// };
+let sessionStub = sinon.stub();
+let mongoStoreStub = sinon.stub();
+let mongoSession;
+
+describe('session/mongo', function() {
+  before(function() {
+    mongoSession = proxyquire('../../../lib/session/mongo', {
+      'express-session': sessionStub,
+      'connect-mongo': sinon.stub().withArgs(sessionStub).returns(mongoStoreStub)
+    });
+    mongoSession(mockConfig);
+  });
+
+  it('creates a session with a mongo store', function() {
+    mongoStoreStub.should.have.been.calledWith({
+      url: mockConfig.mongo.connectionString
+    });
+  });
+
+  it('session is called with config options', function() {
+    sessionStub.should.have.been.calledWith({
+      secret: 'ohsosecret',
+      ttl: 5000,
+      cookie: {
+        secure: true
+      },
+      resave: true,
+      saveUninitialized: true,
+      store: {},
+    });
+  });
+});


### PR DESCRIPTION
### Add in mongo as a session store 🍉
- uses [connect-mongo](https://github.com/jdesboeufs/connect-mongo)
- will be used to store user session information
- previous session options are maintained, but the store is swapped from redis to mongo

### 	Swap out redis for mongo in app.js 🍕 
- Also adds secure/not cookie setup to `session/mongo.js`

### Adds quick test for mongo-connect config 🍍
- Should give us a session
- that session should use mongo as a store