### PR TITLE
Bugfix/departure date and time invalid validation

### DIFF
--- a/acceptance_tests/features/validation.feature
+++ b/acceptance_tests/features/validation.feature
@@ -59,10 +59,19 @@ Scenario: Not entering any details on the departure date and time page
   # Is this your flight page
   And I click "Yes"
   And I continue
-  # Departure date and time page
+  # Departure date and time page with no date and time entered
   And I continue
   Then the validation summary should contain
     """
-    Enter the date you will depart for the UK
+    Enter a valid date
     Please enter a time
+    """
+  # Departure date and time page with invalid date and time entered
+  And I enter the date "99-08-2016" into "Departure date"
+  And I enter the time "35:00" into "Departure time"
+  And I continue
+  Then the validation summary should contain
+    """
+    Enter a valid date
+    Enter a valid time using the 24 hour clock, for example 09:45 or 21:45
     """

--- a/test/validation/departure-date.spec.js
+++ b/test/validation/departure-date.spec.js
@@ -18,7 +18,7 @@ describe('validation/departure-date', function() {
 
     validation.rules('32-08-2016', model).should.deep.equal({
       length: {
-        minimum: 12,
+        minimum: 100,
         message: 'departure-date.invalid'
       }
     });
@@ -31,7 +31,7 @@ describe('validation/departure-date', function() {
 
     validation.rules(moment(), model).should.deep.equal({
       length: {
-        minimum: 12,
+        minimum: 100,
         message: 'departure-date.in-past'
       }
     });
@@ -44,7 +44,7 @@ describe('validation/departure-date', function() {
 
     validation.rules(moment(), model).should.deep.equal({
       length: {
-        minimum: 12,
+        minimum: 100,
         message: 'departure-date.in-future'
       }
     });

--- a/test/validation/departure-time.spec.js
+++ b/test/validation/departure-time.spec.js
@@ -7,38 +7,39 @@ describe('validation/departure-time', function() {
     get: function (key) {
       return this.attributes[key];
     },
-    attributes: {}
-  }
-
-  it('should be no more than 1 hour after the arrival time, Marty', function() {
-    model.attributes = {
+    attributes: {
       'arrival-date': '2016-07-08',
       'departure-date': '2016-07-08',
       'flightDetails': {
         'arrivalTime': '15:00'
       }
-    };
+    }
+  }
 
+  it('should be a valid time', function() {
+    validation.rules('Invalid date', model).should.deep.equal({
+      length: {
+        minimum: 100,
+        message: 'departure-time.invalid'
+      }
+    });
+  });
+
+  it('should be no more than 1 hour after the arrival time, Marty', function() {
     validation.rules('16:01', model).should.deep.equal({
       length: {
-        minimum: 12,
+        minimum: 100,
         message: 'departure-time.departure-after-arrival'
       }
     });
   });
 
   it('should be no more than 24 hours before the arrival time', function() {
-    model.attributes = {
-      'arrival-date': '2016-07-08',
-      'departure-date': '2016-07-07',
-      'flightDetails': {
-        'arrivalTime': '15:00'
-      }
-    };
+    model.attributes['departure-date'] = '2016-07-07';
 
     validation.rules('14:59', model).should.deep.equal({
       length: {
-        minimum: 12,
+        minimum: 100,
         message: 'departure-time.departure-too-far-before-arrival'
       }
     });

--- a/validation/departure-date.js
+++ b/validation/departure-date.js
@@ -11,7 +11,7 @@ module.exports = {
     if (!departureDate.isValid()) {
       return {
         length: {
-          minimum: 12,
+          minimum: 100,
           message: 'departure-date.invalid'
         }
       };
@@ -20,7 +20,7 @@ module.exports = {
     if (departureDate.isBefore(arrivalDateMinusOneDay)) {
       return {
         length: {
-          minimum: 12,
+          minimum: 100,
           message: 'departure-date.in-past'
         }
       };
@@ -29,7 +29,7 @@ module.exports = {
     if (departureDate.isAfter(arrivalDatePlusOneDay)) {
       return {
         length: {
-          minimum: 12,
+          minimum: 100,
           message: 'departure-date.in-future'
         }
       };

--- a/validation/departure-time.js
+++ b/validation/departure-time.js
@@ -7,13 +7,22 @@ module.exports = {
     let departureDateTime = moment(`${model.get('departure-date')} ${fieldValue}`, 'DD-MM-YYYY h:m');
     let arrivalDateTime = moment(`${model.get('arrival-date')} ${model.get('flightDetails').arrivalTime}`, 'DD-MM-YYYY h:m');
 
+    if (fieldValue === 'Invalid date') {
+      return {
+        length: {
+          minimum: 100,
+          message: 'departure-time.invalid'
+        }
+      };
+    }
+
     // We allow time travel of one hour max to compensate for time-zone hopping
     // `departure-time: 8:00` => `arrival-time: 7:00` is okay
     // `departure-time: 8:10` => `arrival-time: 7:00` is not
     if (arrivalDateTime.isBefore(departureDateTime.subtract(1, 'hour'))) {
       return {
         length: {
-          minimum: 12,
+          minimum: 100,
           message: 'departure-time.departure-after-arrival'
         }
       };
@@ -22,7 +31,7 @@ module.exports = {
     if (departureDateTime.isBefore(arrivalDateTime.subtract(24, 'hours'))) {
       return {
         length: {
-          minimum: 12,
+          minimum: 100,
           message: 'departure-time.departure-too-far-before-arrival'
         }
       };


### PR DESCRIPTION
- Updated validation messages
- Changed the min length from 12 to 100 for date validation because we need to compare against 'Invalid date' rather than the date itself
- Added acceptance tests to test the new validation messages
- Added acceptance test to test for an invalid time