### PR TITLE
[NIJ] Acceptance test dates in the future

### DIFF
--- a/acceptance_tests/features/step_definitions/check-your-answers.js
+++ b/acceptance_tests/features/step_definitions/check-your-answers.js
@@ -1,10 +1,36 @@
 'use strict';
 
+const moment = require('moment');
+
+const momentous = (quantity,  direction) => {
+  let action = direction === 'future' ? 'add' : 'subtract'
+  let times = quantity.split(' ');
+  let amount = Number(times[0]);
+  let unit = times[1].slice(0,-1); //day/s month/s
+
+  return moment()[action](amount, unit).format('DD-MM-YYYY'); // e.g. moment().add(2, 'months')
+}
+
+const pullDate = (string) => {
+  let matches = string.match(/^\${"([^"]*)" in the "([^"]*)"}$/);
+
+  if(!matches) {
+    return string;
+  }
+
+  let quantity = matches[1]; // "2 months"
+  let direction = matches[2]; // "future" / "past"
+
+  return momentous(quantity, direction)
+}
+
+const d = (s) => pullDate(s);
+
 module.exports = function () {
 
     this.Then(/^the summary table should contain$/, function (strings) {
         strings.split(/\n/).forEach( function (string) {
-            this.assert.containsText('#summary', string.trim());
+            this.assert.containsText('#summary', d(string.trim()));
         }, this);
     });
 

--- a/acceptance_tests/features/step_definitions/general.js
+++ b/acceptance_tests/features/step_definitions/general.js
@@ -1,9 +1,15 @@
 'use strict';
 
+const moment = require('moment');
 const base = 'http://localhost:8080';
 const urlise = (text) => text.toLowerCase().replace(/[^\w ]+/g, '').replace(/ +/g, '-');
 const setUrl = (app, page) => `${base}/${urlise(app)}/${page ? urlise(page) : ''}`;
-
+const futureDate = (future) => {
+    let times = future.split(' ');
+    let amount = Number(times[0]);
+    let unit = times[1].slice(0,-1); //day/s month/s
+    return moment().add(amount, unit);
+}
 module.exports = function () {
 
     this.When(/^I start the "([^"]*)" app$/, function (app) {
@@ -65,6 +71,24 @@ module.exports = function () {
         let t = time.split(':');
         this.setValue('#'+urlise(field)+'-hours', t[0]);
         this.setValue('#'+urlise(field)+'-minutes', t[1]);
+    });
+
+    this.When(/^I enter a date "([^"]*)" in the future into "([^"]*)"$/, function (future, field) {
+        let val = futureDate(future);
+        console.log('future date', val.format('DD-MM-YYYY'));
+        let target = urlise(field);
+
+        this.setValue('#' + target + '-day', val.format('DD'));
+        this.setValue('#' + target + '-month', val.format('MM'));
+        this.setValue('#' + target + '-year', val.format('YYYY'));
+    });
+
+    //And the "Arrival date" should contain a date "2 months" in the future
+    this.Then(/^the "([^"]*)" should contain a date "([^"]*)" in the future$/, function (field, future) {
+        let val = futureDate(future);
+        let target = urlise(field);
+        console.log(val.format('DD-MM-YYYY'), 'does it need formatting?');
+        this.assert.containsText('.' + target, val.format('DD-MM-YYYY'));
     });
 
     this.When(/^I continue$/, function () {

--- a/acceptance_tests/features/step_definitions/update-journey-smoke.js
+++ b/acceptance_tests/features/step_definitions/update-journey-smoke.js
@@ -1,19 +1,10 @@
 'use strict';
 
 const config = require('../../../config');
-const moment = require('moment');
 const base = config.baseUrl || 'http://localhost';
 const port = config.port || '8080';
 const request = require('request');
 
-const urlise = (text) => text.toLowerCase().replace(/[^\w ]+/g, '').replace(/ +/g, '-');
-
-const futureDate = (future) => {
-    let times = future.split(' ');
-    let amount = Number(times[0]);
-    let unit = times[1].slice(0,-1); //day/s month/s
-    return moment().add(amount, unit);
-}
 
 const fixture = {"objectId":"56ec2057084d726f6a4611b8","passport":{"givenNames":"Ahmed","surname":"Shehab Malbas Abdulla Alobeidli","passportNumber":"12345678Y","expiryDate":"2018-04-27","issueDate":"2013-04-28","placeOfIssue":"Kuwait","gender":"F","dateOfBirth":"1987-08-12","placeOfBirth":"KUWAIT","countryOfBirth":"KWT","nationality":"ARE","holdOtherNationalities":"No","heldPreviousNationalities":"No"},"payment":{"orderCode":"Free","feeInPence":0,"paid":true,"paymentDate":"2016-03-18 15:35:51"},"contactDetails":{"emailAddress":"test@gmail.com","secondEmail":"testing@gmail.com","homeAddress":["My House","STREET 32","HOUSE NUMBER 16","","KWT","00000"],"mobilePhoneNumber":"+123-99028325","phoneNumber":"+123-44422555","countryAppliedFrom":"Kuwait","countryAppliedFromCode":"KWT","areYouEmployed":"No"},"journey":{"travelBy":"Plane","arrivalTravel":"BA0156","arrivalDate":"2016-08-21","departureForUKDate":"2016-04-30 08:20:00","arrivalTime":"12:15","portOfArrival":"London - Heathrow","portOfArrivalCode":"LHR","ukAddress":["The hotel in London","Westminster, London W1 7YT,","","","W1 7YT"],"departureDate":"2016-04-21","departureTravel":"BA157","portOfDeparture" : "London - Heathrow, LHR","inwardDepartureCountry":"KWT","inwardDeparturePort":"Kuwait - Kuwait Intl","inwardDeparturePortCode":"KWI","reasonForTravel":"Tourism","travelWithOthers":"No","knowDepartureDetails":"Yes","ukVisitPhoneNumber":"+12345234234","visitMoreThanOnce":"No"},"miscellaneous":{"onBehalfOfMinor":"No","asAnAgent":"No", "flightDetailsCheck":"Yes"},"passportFileId":"56ec1bd8aee7c384447463f0","applicationReference":"EVW123456"};
 
@@ -47,22 +38,4 @@ module.exports = function () {
         this.url(`${base}:${port}/update-journey-details/how-will-you-arrive?evwNumber=EVW123456&token=74d3e5a47154150525964d90d0a99138a2633b49fbd9f829f9387414c1a458ef`)
         .waitForElementVisible('body', 1000);
     });
-
-    this.Then(/^I enter a date "([^"]*)" in the future into "([^"]*)"$/, function (future, field) {
-        let val = futureDate(future);
-        let target = urlise(field);
-
-        this.setValue('#' + target + '-day', val.day());
-        this.setValue('#' + target + '-month', val.month());
-        this.setValue('#' + target + '-year', val.year());
-    });
-
-    // this.Then(/^the "([^"]*)" should contain a date "([^"]*)" in the future$/, function (field, future) {
-    //     let val = futureDate(future);
-    //     let target = urlise(field);
-    //     this.assert.containsText('#' + target + '-day', val.day());
-    //     this.assert.containsText('#' + target + '-month', val.month());
-    //     this.assert.containsText('#' + target + '-year', val.year());
-    // });
-
 }

--- a/acceptance_tests/features/update-journey-details.feature
+++ b/acceptance_tests/features/update-journey-details.feature
@@ -19,7 +19,7 @@ Scenario: Entering new flight details and correct flight found
   # Arrival date page
   Then I should be on the "Arrival date" page of the "Update journey details" app
   And the page title should contain "Your new flight details"
-  And I enter the date "10-08-2016" into "Arrival date"
+  And I enter a date "2 months" in the future into "Arrival date"
   And I continue
   # Is this your flight page
   Then I should be on the "Is this your flight" page of the "Update journey details" app
@@ -27,7 +27,7 @@ Scenario: Entering new flight details and correct flight found
   And the "Flight number" should contain "KU101"
   And the "Departure airport" should contain "Dubai"
   And the "Arrival airport" should contain "London - Gatwick"
-  And the "Arrival date" should contain "10-08-2016"
+  And the "Arrival date" should contain a date "2 months" in the future
   And the "Arrival time" should contain "19:45"
   And I click "Yes"
   And I continue
@@ -36,8 +36,8 @@ Scenario: Entering new flight details and correct flight found
   And the page title should contain "Your journey to the UK"
   And the "Data flight number" should contain "KU101"
   And the "Data departure airport" should contain "Dubai"
-  And I enter the date "09-08-2016" into "Departure date"
-  And I enter the time "23:15" into "Departure time"
+  And I enter a date "2 months" in the future into "Departure date"
+  And I enter the time "07:15" into "Departure time"
   And I continue
   # Check your answers page
   Then the page title should contain "Check your answers"
@@ -48,15 +48,15 @@ Scenario: Entering new flight details and correct flight found
     Departure airport
                       Dubai
     Departure date
-                      09-08-2016
+                      ${"2 months" in the "future"}
     Departure time
-                      23:15
+                      7:15
     Flight number
                       KU101
     Arrival airport
                       London - Gatwick
     Arrival date
-                      10-08-2016
+                      ${"2 months" in the "future"}
     Arrival time
                       19:45
     """
@@ -89,7 +89,7 @@ Scenario: Entering new flight details and flight not found
   # Arrival date page
   Then I should be on the "Arrival date" page of the "Update journey details" app
   And the page title should contain "Your new flight details"
-  And I enter the date "08-08-2016" into "Arrival date"
+  And I enter a date "2 months" in the future into "Arrival date"
   And I continue
   # Flight not found page
   Then I should be on the "Flight not found" page of the "Update journey details" app
@@ -121,7 +121,7 @@ Scenario: Entering new flight details and incorrect flight found
   # Arrival date page
   Then I should be on the "Arrival date" page of the "Update journey details" app
   And the page title should contain "Your new flight details"
-  And I enter the date "09-08-2016" into "Arrival date"
+  And I enter a date "2 months" in the future into "Arrival date"
   And I continue
   # Is this your flight page
   # Flight details on this page have been tested in the last test so we only need to test the flow here


### PR DESCRIPTION
### Change static dates to dynamic future dates 🕙 
- instead of hardcoding e.g. `"10-08-2016"` we can now pass in future amounts
- e.g. `"2 months" in the "future"`
- changes all instances of both adding and expecting dates to be future expectations

### 	Move future date checking into `general.js` ⌚ 
We're going to check for future dates in an increasingly large number of places so `general` seems to be correct

### Check each string in the summary table for a date ⌛ 
- Wrap each string we check in a matcher
- Quite a specific pattern to match
  - `'${"amount unit" in the "direction"}'`
  - e.g. `'${"2 months" in the "future"}'`
