### PR TITLE
EVW-1538 User self service error page - Number of flight changes

### DIFF
--- a/acceptance_tests/features/find-your-application.feature
+++ b/acceptance_tests/features/find-your-application.feature
@@ -26,6 +26,13 @@ Scenario: Too late to change
   And I click confirm details
   Then I should be on the "EVW expired" page of the "Find your application" app
 
+Scenario: Updated too many times
+  Given I start the "Find your application" app
+  When I enter "UPDATELIMIT" into "EVW number"
+  And I enter the date "20-10-1978" into "dob"
+  And I click confirm details
+  Then I should be on the "Update limit reached" page of the "Find your application" app
+
 Scenario: Case not found
   Given I start the "Find your application" app
   When I enter "NOFOUND" into "EVW number"

--- a/apps/find-your-application/steps.js
+++ b/apps/find-your-application/steps.js
@@ -24,6 +24,10 @@ module.exports = {
     {
       target: '/evw-not-verified',
       condition: (req) => req.sessionModel.get('evwLookupError') === 'CASE_NOT_VERIFIED'
+    },
+    {
+      target: '/update-limit-reached',
+      condition: (req) => req.sessionModel.get('evwLookupError') === 'UPDATE_LIMIT_REACHED'
     }]
   },
   '/link-sent': {
@@ -35,5 +39,8 @@ module.exports = {
   },
   '/evw-not-verified': {
     template: 'evw-not-verified'
+  },
+  '/update-limit-reached': {
+    template: 'update-limit-reached'
   }
 };

--- a/apps/find-your-application/translations/src/en/pages.json
+++ b/apps/find-your-application/translations/src/en/pages.json
@@ -14,5 +14,12 @@
   "evw-not-verified": {
     "header": "Electronic visa waiver not yet verified",
     "content": "Your application is still awaiting verification. We will email you as soon as your current application has been processed."
+  },
+  "update-limit-reached": {
+    "header": "You can't change your flight details again",
+    "content-1": "You can only change your flight details twice.",
+    "content-2": "To travel on a different flight, you will need to apply for a",
+    "return-to-start": "new electronic visa waiver",
+    "return-to-govuk": "Back to GOV.UK"
   }
 }

--- a/apps/find-your-application/views/update-limit-reached.html
+++ b/apps/find-your-application/views/update-limit-reached.html
@@ -1,0 +1,25 @@
+{{<layout}}
+
+{{$journeyHeader}}
+{{#t}}journey.header{{/t}}
+{{/journeyHeader}}
+
+{{$validationSummary}}
+{{> partials-validation-summary}}
+{{/validationSummary}}
+
+{{$propositionHeader}}
+{{> partials-navigation}}
+{{/propositionHeader}}
+
+{{$content}}
+<h1 class="heading-large">{{#t}}pages.update-limit-reached.header{{/t}}</h1>
+<p>{{#t}}pages.update-limit-reached.content-1{{/t}}</p>
+<p>
+  {{#t}}pages.update-limit-reached.content-2{{/t}}
+  <a href="https://www.electronic-visa-waiver.service.gov.uk">{{#t}}pages.update-limit-reached.return-to-start{{/t}}</a>.
+</p>
+<a href="https://www.gov.uk" class="button">{{#t}}pages.update-limit-reached.return-to-govuk{{/t}}</a>
+{{/content}}
+
+{{/layout}}

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-filenames": "^1.0.0",
     "eslint-plugin-mocha": "^3.0.0",
     "eslint-plugin-one-variable-per-var": "0.0.3",
-    "evw-integration-stub": "^1.2.0",
+    "evw-integration-stub": "^1.4.0",
     "hof-transpiler": "0.0.6",
     "jscs": "^3.0.4",
     "mocha": "^2.2.5",

--- a/test/lib/evw-lookup.spec.js
+++ b/test/lib/evw-lookup.spec.js
@@ -37,7 +37,7 @@ describe('lib/evw-lookup', function () {
     it('should return success', function () {
       return lookup.find('validevwnumber10', '10/10/1980')
         .should.eventually.have.property('body').contains({
-          success: true
+          emailAddress: 'someone@example.com'
         });
     });
 


### PR DESCRIPTION
- Added `/update-limit-reached` page to display to the user if they try to update their application more than twice.
- Added acceptance tests to check that the page is correctly displayed in this scenario.
- Fixed unit test which checks the value that is returned when an EVW is found successfully...it now returns an email address instead of a success flag.

![update-limit-reached-page](https://cloud.githubusercontent.com/assets/6839214/17737424/f8f189ec-6484-11e6-8b04-e000f852705c.png)
