### PR TITLE
[EVW-1619] Multi-departures pt I: Expect a list of departures

### DIFF
--- a/acceptance_tests/features/step_definitions/general.js
+++ b/acceptance_tests/features/step_definitions/general.js
@@ -75,7 +75,7 @@ module.exports = function () {
 
     this.When(/^I enter a date "([^"]*)" in the future into "([^"]*)"$/, function (future, field) {
         let val = futureDate(future);
-        console.log('future date', val.format('DD-MM-YYYY'));
+        // console.log('future date', val.format('DD-MM-YYYY'));
         let target = urlise(field);
 
         this.setValue('#' + target + '-day', val.format('DD'));
@@ -87,7 +87,7 @@ module.exports = function () {
     this.Then(/^the "([^"]*)" should contain a date "([^"]*)" in the future$/, function (field, future) {
         let val = futureDate(future);
         let target = urlise(field);
-        console.log(val.format('DD-MM-YYYY'), 'does it need formatting?');
+        // console.log(val.format('DD-MM-YYYY'), 'does it need formatting?');
         this.assert.containsText('.' + target, val.format('DD-MM-YYYY'));
     });
 

--- a/apps/update-journey-details/controllers/arrival-date.js
+++ b/apps/update-journey-details/controllers/arrival-date.js
@@ -39,4 +39,4 @@ module.exports = class ArrivalDateController extends EvwBaseController {
       });
     });
   }
-}
+};

--- a/apps/update-journey-details/controllers/arrival-date.js
+++ b/apps/update-journey-details/controllers/arrival-date.js
@@ -28,7 +28,12 @@ module.exports = class ArrivalDateController extends EvwBaseController {
 
         // Flight found
         if (typeof flight !== 'undefined') {
+          let departure = flightLookup.mapDepartures(flight.departures)[0];
           let mappedFlight = flightLookup.mapFlight(flight, req.sessionModel);
+
+          Object.assign(mappedFlight, departure); // add first departure to flight
+          delete mappedFlight.departures;
+
           req.sessionModel.set('flightDetails', mappedFlight);
         }  else {
           req.sessionModel.set('flightDetails', null);

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -3,10 +3,6 @@
 let features = require('characteristic')(__dirname + '/../../config/features.yml');
 
 module.exports = {
-  // '/': {
-  //   controller: require('../common/controllers/start'),
-  //   next: '/how-will-you-arrive'
-  // },
   '/how-will-you-arrive': {
     template: 'how-will-you-arrive',
     controller: require('./controllers/how-will-you-arrive'),
@@ -47,6 +43,11 @@ module.exports = {
       target: '/flight-not-found',
       condition: function(req) {
         return req.sessionModel.get('flightDetails') === null;
+      }
+    }, {
+      target: '/check-departure',
+      condition: function(req) {
+        return req.sessionModel.get('flightDetails').departures.length > 1;
       }
     }]
   },

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -44,11 +44,6 @@ module.exports = {
       condition: function(req) {
         return req.sessionModel.get('flightDetails') === null;
       }
-    }, {
-      target: '/check-departure',
-      condition: function(req) {
-        return req.sessionModel.get('flightDetails').departures.length > 1;
-      }
     }]
   },
   '/is-this-your-flight': {

--- a/lib/flight-lookup.js
+++ b/lib/flight-lookup.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const request = require('request');
 const service = require('../config').flightService;
 const moment = require('moment');
@@ -61,20 +63,32 @@ module.exports = {
             ].reverse().join('-'), 'YYYY-M-D').format('YYYY-MM-DD')
         };
     },
+
+    mapDepartures: function (departures) {
+
+        let departCode = (departure) => this.search(airports, {
+            key: 'code',
+            val: departure.port
+        })['country-code'];
+
+        return departures.map((departure) => {
+            return {
+                inwardDepartureCountryPlane: this.country(departCode(departure)),
+                inwardDepartureCountryPlaneCode: departCode(departure),
+                departureAirport: this.airport(departure.port),
+                inwardDeparturePortPlaneCode: departure.port
+            };
+        });
+    },
+
     // map service response to useful form elements
     mapFlight: function(flight, sessionModel) {
+
         var arrivalDate = this.momentDate(flight.arrival);
-        var departCode = this.search(airports, {
-            key: 'code',
-            val: flight.departure.port
-        })['country-code'];
 
         return {
             flightNumber: sessionModel.get('flight-number'),
-            inwardDepartureCountryPlane: this.country(departCode),
-            inwardDepartureCountryPlaneCode: departCode,
-            departureAirport: this.airport(flight.departure.port),
-            inwardDeparturePortPlaneCode: flight.departure.port,
+            departures: this.mapDepartures(flight.departures),
             arrivalAirport: this.airport(flight.arrival.port),
             portOfArrivalPlaneCode: flight.arrival.port,
             arrivalDate: `${arrivalDate.format('DD')}-${arrivalDate.format('MM')}-${arrivalDate.format('YYYY')}`,

--- a/mocks/flight/post/details.js
+++ b/mocks/flight/post/details.js
@@ -1,21 +1,29 @@
-var tpl = function(params, query, body) {
+'use strict';
+
+var tpl = function (params, query, body) {
     return {
         flightNumber: body.flightNumber,
-        departure: {
+        departures: [{
             port: 'DXB',
             country: 'AE'
-        },
+        }],
         arrival: {
             port: 'LGW',
             date: body.arrivalDate,
             time: '1845'
-        }
+        },
+        params: params,
+        query: query,
+        body: body
     };
 };
 
-module.exports = {
+var search = {
+
     path: '/check-flight-details',
+
     cache: false,
+
     status: function(req, res) {
         // mock fail state
         if(req.body.flightNumber === 'FAIL999') {
@@ -26,43 +34,51 @@ module.exports = {
             });
         }
     },
+
     template: {
         flights: function (params, query, body) {
 
-            if (!body.flightNumber || !body.arrivalDate) {
+            if(!body.flightNumber || !body.arrivalDate) {
                 return [];
             }
 
             // Fake up a no-flights scenario
-            if (body.flightNumber === 'NO0001') {
+            if(body.flightNumber === 'NO0001') {
                 return [];
             }
 
             // fake up too many results
-            if (body.flightNumber === 'SUM1000') {
+            if(body.flightNumber === 'SUM1000') {
                 return [
                     tpl(params, query, body),
                     tpl(params, query, body)
                 ];
             }
 
+            // fake up multi-leg flight
+            if(body.flightNumber === 'LEG0001') {
+                let res = tpl(params, query, body);
+
+                // add additional departure
+                res.departures.push({
+                    port: 'AUH',
+                    country: 'AE'
+                });
+
+                return [
+                    res
+                ];
+            }
+
             // fake up service is down
             // Fake up sending incorrect information
-            return [{
-                flightNumber: body.flightNumber,
-                departure: {
-                    port: 'DXB',
-                    country: 'AE'
-                },
-                arrival: {
-                    port: 'LGW',
-                    date: body.arrivalDate,
-                    time: '1845'
-                },
-                params: params,
-                query: query,
-                body: body
-            }];
+            return [
+                tpl(params, query, body)
+            ];
+
         }
     }
 };
+
+module.exports = search;
+module.exports.tpl = tpl;


### PR DESCRIPTION
### 	flight lookup 'departure' => 'departures'

- Departures now always returned as a list
- `mapDepartures` takes a response from the `flight-forecast-service` and maps it to form values e.g. `inwardDepartureCountryPlane` etc
- mock updated to pass back a list

### Arrival date controller adds first departure result

- Should allow us a quick release of the app whilst we work on getting the departures-check interstitial page completed
- Should operate as before, but subscribes to new model of multiple departures

### pt. II: IInterstiitiial

Next step will be to ship a new `check-departures` interstitial page

#### Same as before...

![screen shot 2016-08-24 at 15 04 22](https://cloud.githubusercontent.com/assets/120181/17933521/44e8367a-6a0c-11e6-97a4-9802163b0e95.png)

