### PR TITLE
[EVW-1619] display multiple departure options page

### DIFF
--- a/acceptance_tests/features/step_definitions/general.js
+++ b/acceptance_tests/features/step_definitions/general.js
@@ -52,6 +52,10 @@ module.exports = function () {
         this.click('#'+urlise(id));
     });
 
+    this.When(/^I click exact id "([^"]*)"$/, function (id) {
+        this.click('#'+id);
+    });
+
     this.When(/^I enter "([^"]*)" into "([^"]*)"$/, function (value, field) {
         this.setValue('#'+urlise(field), value);
     });

--- a/acceptance_tests/features/update-journey-details.feature
+++ b/acceptance_tests/features/update-journey-details.feature
@@ -76,6 +76,50 @@ Scenario: Entering new flight details and correct flight found
   And the "header notice complete" should contain "Request received"
   And the reference number should be present
 
+Scenario: Multi-leg flight
+
+  Given I start the Update journey details app
+  When I click "By plane"
+  And I continue
+  When I enter "BA0072" into "Flight number"
+  And I continue
+  Then I enter a date "2 months" in the future into "Arrival date"
+  And I continue
+
+  # Multi-leg page
+  And the page title should contain "Your journey to the UK"
+  When I click exact id "departures-MCT"
+  And I continue
+
+  Then the page title should contain "Is this your flight to the UK?"
+  And the "Flight number" should contain "BA0072"
+  And the "Departure airport" should contain "Muscat - Seeb"
+  And I click "Yes"
+  And I continue
+
+  # Departure date and time page
+  Then I enter a date "2 months" in the future into "Departure date"
+  And I enter the time "07:15" into "Departure time"
+  And I continue
+
+  # Check your answers page
+  Then the page title should contain "Check your answers"
+  And the summary table should contain
+    """
+    Departure country
+                      Oman
+    Departure airport
+                      Muscat - Seeb
+    Departure date
+                      ${"2 months" in the "future"}
+    """
+  And I continue
+  # Declaration page
+  Then I should be on the "Declaration" page of the "Update journey details" app
+  And I click id "Accept Declaration"
+  And I continue
+  Then the reference number should be present
+
 Scenario: Entering new flight details and flight not found
 
   Given I start the Update journey details app

--- a/apps/update-journey-details/controllers/arrival-date.js
+++ b/apps/update-journey-details/controllers/arrival-date.js
@@ -28,11 +28,13 @@ module.exports = class ArrivalDateController extends EvwBaseController {
 
         // Flight found
         if (typeof flight !== 'undefined') {
-          let departure = flightLookup.mapDepartures(flight.departures)[0];
+
+          let departures = flightLookup.mapDepartures(flight.departures);
           let mappedFlight = flightLookup.mapFlight(flight, req.sessionModel);
 
-          Object.assign(mappedFlight, departure); // add first departure to flight
-          delete mappedFlight.departures;
+          if(flight.departures.length === 1) {
+            Object.assign(mappedFlight, departures[0]); // add first departure to flight
+          }
 
           req.sessionModel.set('flightDetails', mappedFlight);
         }  else {

--- a/apps/update-journey-details/controllers/choose-departure-airport.js
+++ b/apps/update-journey-details/controllers/choose-departure-airport.js
@@ -1,11 +1,6 @@
 'use strict';
 
-const path = require('path');
 const EvwBaseController = require('../../common/controllers/evw-base');
-const hof = require('hof');
-const i18n = hof.i18n({
-  path: path.resolve(__dirname, '../../update-journey-details/translations/__lng__/__ns__.json')
-});
 
 module.exports = class ChooseDepartureAirportController extends EvwBaseController {
 
@@ -28,16 +23,13 @@ module.exports = class ChooseDepartureAirportController extends EvwBaseControlle
         label: item.departureAirport
       };
     });
-    let legend = i18n.translate('fields.departures.preLegend');
-
-    legend = `${legend} ${flight.flightNumber}`; // => e.g. 'Please select where you are boarding flight BA0072'
 
     let deps = Object.assign(res.locals.options.fields.departures, {
       options: departures
     });
 
     let ret = Object.assign({
-      legend: legend,
+      flightNumber: flight.flightNumber,
       departures: deps
     }, super.locals.call(this, req, res));
 

--- a/apps/update-journey-details/controllers/choose-departure-airport.js
+++ b/apps/update-journey-details/controllers/choose-departure-airport.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const path = require('path');
+const EvwBaseController = require('../../common/controllers/evw-base');
+const hof = require('hof');
+const i18n = hof.i18n({
+  path: path.resolve(__dirname, '../../update-journey-details/translations/__lng__/__ns__.json')
+});
+
+module.exports = class ChooseDepartureAirportController extends EvwBaseController {
+
+  locals(req, res) {
+    let flight = req.sessionModel.get('flightDetails');
+    let departures = flight.departures.map((item) => {
+      return {
+        value: item.inwardDeparturePortPlaneCode,
+        label: item.departureAirport
+      };
+    });
+    let legend = i18n.translate('fields.departures.preLegend');
+
+    legend = `${legend} ${flight.flightNumber}`; // => e.g. 'Please select where you are boarding flight BA0072'
+
+    let ret = Object.assign({
+      legend: legend
+    }, super.locals.call(this, req, res));
+
+    Object.assign(res.locals.options.fields.departures, {
+      options: departures
+    });
+
+    return ret;
+  }
+
+};

--- a/apps/update-journey-details/controllers/choose-departure-airport.js
+++ b/apps/update-journey-details/controllers/choose-departure-airport.js
@@ -9,6 +9,17 @@ const i18n = hof.i18n({
 
 module.exports = class ChooseDepartureAirportController extends EvwBaseController {
 
+  process(req, res, callback) {
+    super.process(req, res, () => {
+      let flight = req.sessionModel.get('flightDetails');
+      let choice = req.form.values.departures;
+      let update = flight.departures.find((i) => i.inwardDeparturePortPlaneCode === choice);
+      let mapped = Object.assign(flight, update);
+      req.sessionModel.set('flightDetails', mapped);
+      callback();
+    });
+  }
+
   locals(req, res) {
     let flight = req.sessionModel.get('flightDetails');
     let departures = flight.departures.map((item) => {
@@ -21,13 +32,14 @@ module.exports = class ChooseDepartureAirportController extends EvwBaseControlle
 
     legend = `${legend} ${flight.flightNumber}`; // => e.g. 'Please select where you are boarding flight BA0072'
 
-    let ret = Object.assign({
-      legend: legend
-    }, super.locals.call(this, req, res));
-
-    Object.assign(res.locals.options.fields.departures, {
+    let deps = Object.assign(res.locals.options.fields.departures, {
       options: departures
     });
+
+    let ret = Object.assign({
+      legend: legend,
+      departures: deps
+    }, super.locals.call(this, req, res));
 
     return ret;
   }

--- a/apps/update-journey-details/fields/choose-departure-airport.js
+++ b/apps/update-journey-details/fields/choose-departure-airport.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  'departures': {
+    validate: ['required'],
+    className: ['form-group']
+  }
+};

--- a/apps/update-journey-details/fields/index.js
+++ b/apps/update-journey-details/fields/index.js
@@ -5,6 +5,7 @@ module.exports = Object.assign(
   require('./email-us'),
   require('./flight-number'),
   require('./arrival-date'),
+  require('./choose-departure-airport'),
   require('./is-this-your-flight'),
   require('./departure-date-and-time'),
   require('./declaration')

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -44,7 +44,20 @@ module.exports = {
       condition: function(req) {
         return req.sessionModel.get('flightDetails') === null;
       }
+    }, {
+      target: '/choose-departure-airport',
+      condition: function(req) {
+        return req.sessionModel.get('flightDetails') && req.sessionModel.get('flightDetails').departures.length > 1;
+      }
     }]
+  },
+  '/choose-departure-airport': {
+    template: 'choose-departure-airport',
+    controller: require('./controllers/choose-departure-airport'),
+    fields: [
+      'departures'
+    ],
+    next: '/is-this-your-flight'
   },
   '/is-this-your-flight': {
     template: 'is-this-your-flight',

--- a/apps/update-journey-details/translations/src/en/fields.json
+++ b/apps/update-journey-details/translations/src/en/fields.json
@@ -61,6 +61,11 @@
   "departure-time-minutes": {
     "label": "Minutes"
   },
+  "departures": {
+    "legend": " ",
+    "preLegend": "Please select where you are boarding flight",
+    "options": {}
+  },
   "is-this-your-flight": {
     "options": {
       "yes": {

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -97,6 +97,9 @@
     },
     "retry-button": "Try again"
   },
+  "choose-departure-airport": {
+    "header": "Your journey to the UK"
+  },
   "declaration": {
     "header": "Declaration",
     "content": "I confirm that:",

--- a/apps/update-journey-details/translations/src/en/validation.json
+++ b/apps/update-journey-details/translations/src/en/validation.json
@@ -34,5 +34,8 @@
     "invalid": "Enter a valid time using the 24 hour clock, for example 09:45 or 21:45",
     "departure-after-arrival": "Your departure cannot be after your arrival",
     "departure-too-far-before-arrival": "The date your flight to the UK takes off cannot be more than 24 hours before it arrives in the UK"
+  },
+  "departures": {
+    "required": "Please choose a departure airport"
   }
 }

--- a/apps/update-journey-details/views/choose-departure-airport.html
+++ b/apps/update-journey-details/views/choose-departure-airport.html
@@ -22,7 +22,10 @@
 {{$form}}
 
 <br>
-<span class="form-label-bold">{{legend}}</span>
+<span class="form-label-bold">{{#t}}fields.departures.preLegend{{/t}}
+  <span class="data-flight-number">{{flightNumber}}</span>
+</span>
+
 {{#radio-group}}departures{{/radio-group}}
 
 {{#input-submit}}continue{{/input-submit}}

--- a/apps/update-journey-details/views/choose-departure-airport.html
+++ b/apps/update-journey-details/views/choose-departure-airport.html
@@ -1,0 +1,36 @@
+{{<layout}}
+
+{{$journeyHeader}}
+{{#t}}journey.header{{/t}}
+{{/journeyHeader}}
+
+{{$validationSummary}}
+{{> partials-validation-summary}}
+{{/validationSummary}}
+
+{{$propositionHeader}}
+{{> partials-navigation}}
+{{/propositionHeader}}
+
+{{$content}}
+<header>
+    <h1 class="heading-large">{{#t}}pages.choose-departure-airport.header{{/t}}</h1>
+</header>
+
+{{<partials-form}}
+
+{{$form}}
+
+<br>
+<span class="form-label-bold">{{legend}}</span>
+{{#radio-group}}departures{{/radio-group}}
+
+{{#input-submit}}continue{{/input-submit}}
+
+{{/form}}
+
+{{/partials-form}}
+
+{{/content}}
+
+{{/layout}}

--- a/mocks/flight/post/details.js
+++ b/mocks/flight/post/details.js
@@ -56,13 +56,13 @@ var search = {
             }
 
             // fake up multi-leg flight
-            if(body.flightNumber === 'LEG0001') {
+            if(body.flightNumber === 'BA0072') {
                 let res = tpl(params, query, body);
 
                 // add additional departure
                 res.departures.push({
-                    port: 'AUH',
-                    country: 'AE'
+                    port: 'MCT',
+                    country: 'OM'
                 });
 
                 return [

--- a/test/apps/update-journey-details/controllers/choose-departure-airport.spec.js
+++ b/test/apps/update-journey-details/controllers/choose-departure-airport.spec.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const ChooseDepartureAirport = require('../../../../apps/update-journey-details/controllers/choose-departure-airport');
+const controller = new ChooseDepartureAirport({template: 'choose-departure-airport'});
+const flightDetails = {
+  flightNumber: 'LOL10000',
+  departures:
+  [
+    {
+      inwardDepartureCountryPlane: 'United Arab Emirates',
+      inwardDepartureCountryPlaneCode: 'ARE',
+      departureAirport: 'Dubai',
+      inwardDeparturePortPlaneCode: 'DXB'
+    }, {
+      inwardDepartureCountryPlane: 'Oman',
+      inwardDepartureCountryPlaneCode: 'OMN',
+      departureAirport: 'Muscat - Seeb',
+      inwardDeparturePortPlaneCode: 'MCT'
+    }
+  ]
+};
+const req = {
+  sessionModel: {
+    get: function (key) {
+      return this.attributes[key];
+    },
+    set: function (key, value) {
+      return this.attributes[key] = value;
+    },
+    attributes: {
+      flightDetails: flightDetails
+    }
+  },
+  form: {
+    values: {
+      departures: 'DXB'
+    }
+  },
+  params: {}
+};
+
+describe('apps/update-journey-details/controllers/choose-departure-airport', function () {
+
+  describe('process', function () {
+    it('assigns user choice to sessionModel', function () {
+      controller.process(req, null, () => false);
+      let flight = req.sessionModel.get('flightDetails');
+      flight.should.include.property('departureAirport').equal('Dubai');
+      flight.should.include.property('inwardDeparturePortPlaneCode').equal('DXB');
+      flight.should.include.property('inwardDepartureCountryPlaneCode').equal('ARE');
+      flight.should.include.property('inwardDepartureCountryPlane').equal('United Arab Emirates')
+    });
+  });
+
+  describe('locals', function () {
+    let res;
+
+    before(function () {
+       res = {
+        locals: {
+          options: {
+            fields: {
+              departures: {}
+            }
+          }
+        }
+      };
+    });
+
+    it('adds flight number to locals', function () {
+      controller.locals(req, res, () => false)
+      .should.include.property('legend')
+      .equal('Please select where you are boarding flight LOL10000');
+    });
+
+    it('adds a list of departures to render', function () {
+      controller.locals(req, res, () => false)
+      .departures.options
+      .should.deep.equal([
+        {
+          label: 'Dubai',
+          value: 'DXB'
+        }, {
+          label: 'Muscat - Seeb',
+          value: 'MCT'
+        }
+      ])
+    });
+  });
+
+});

--- a/test/apps/update-journey-details/controllers/choose-departure-airport.spec.js
+++ b/test/apps/update-journey-details/controllers/choose-departure-airport.spec.js
@@ -69,8 +69,8 @@ describe('apps/update-journey-details/controllers/choose-departure-airport', fun
 
     it('adds flight number to locals', function () {
       controller.locals(req, res, () => false)
-      .should.include.property('legend')
-      .equal('Please select where you are boarding flight LOL10000');
+      .should.include.property('flightNumber')
+      .equal('LOL10000');
     });
 
     it('adds a list of departures to render', function () {

--- a/test/lib/flight-lookup.spec.js
+++ b/test/lib/flight-lookup.spec.js
@@ -101,7 +101,7 @@ describe('lib/flight-lookup', function() {
 
             describe('multiple results', function () {
                 before(function (done) {
-                    flightLookup.findFlight('LEG0001', '2016-08-09').then((data) => {
+                    flightLookup.findFlight('BA0072', '2016-08-09').then((data) => {
                         flightData = data.body.flights[0];
                         done();
                     });
@@ -117,10 +117,10 @@ describe('lib/flight-lookup', function() {
                             inwardDeparturePortPlaneCode: 'DXB'
                         },
                         {
-                            inwardDepartureCountryPlane: 'United Arab Emirates',
-                            inwardDepartureCountryPlaneCode: 'ARE',
-                            departureAirport: 'Abu Dhabi',
-                            inwardDeparturePortPlaneCode: 'AUH'
+                            departureAirport: 'Muscat - Seeb',
+                            inwardDepartureCountryPlane: 'Oman',
+                            inwardDepartureCountryPlaneCode: 'OMN',
+                            inwardDeparturePortPlaneCode: 'MCT'
                         }
                     ]);
                 });


### PR DESCRIPTION
![screen shot 2016-08-26 at 14 46 05](https://cloud.githubusercontent.com/assets/120181/18007400/d913f57e-6b9b-11e6-9a15-7c3492f84303.png)

###	Swaps mock flight number: LEG0001 => BA0072
- Should mean multileg departure sections can be tested against the stubs and the deployed `flight-forecast-service`
- same as with `evw-customer` app [changes](https://github.com/UKHomeOffice/evw-customer/commit/0f3b6967a3254683b30ae4e886d51865794918c5)

 ### Adds `choose-departure-airport` section
- Nasty hack to add in flight number (but how to edit the legend prop inside locals without lots of locals manipulation?)
- 'legend' field of departures left as single space string 😢 

### Adds Unit tests for controller
- `process` picks the departure from departures array using `.find`
- Adds test for `locals` and `process` methods

### 	Adds acceptance test for multi-leg departures
- Adds 'exact' matcher for ID clicking in `general.js` for when you need to click something with a `'weird-ID'`
- Strimmed down version of happy path, checking for a small subset of usual information