### PR TITLE
EVW-1622 Add logstashforwarder entries for `evw-customer` and `evw-self-serve`

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,6 +7,7 @@
 let port = process.env.PORT || 8080;
 
 module.exports = {
+  appName: 'EVW Self Serve',
   env: process.env.NODE_ENV,
   port: port,
   baseUrl: process.env.BASE_URL || 'http://localhost',

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -17,28 +17,54 @@ var colors = {
   warn: 'yellow',
   error: 'red'
 };
+// Format nested json objects into array-style strings
+let formatMeta = (meta) => {
+  if (Object.keys(meta).length) {
+    let formatted = [];
+    Object.keys(meta).forEach(function(key) {
+      if (typeof meta[key] === 'object') {
+        if (Object.keys(meta[key]).length) {
+          let metaVals = formatMeta(meta[key]);
+          if (isNaN(key)) {
+            metaVals = `${key}=[${metaVals}]`;
+          }
+          formatted.push(metaVals);
+        }
+      } else {
+        formatted.push(`${key}=${meta[key]}`);
+      }
+    });
+    return formatted.join(', ');
+  }
+};
+let formatMessage = (options) => {
+  let metaValues = formatMeta(options.meta);
 
-loggingTransports.push(
-  new (winston.transports.Console)({
-    json: (notProd === true) ? false : true,
-    timestamp: true,
-    colorize: true,
-    stringify: function stringify(obj) {
-      return JSON.stringify(obj);
-    }
-  })
-);
+  if (options.message && metaValues) {
+    return `${options.message}: ${metaValues}`;
+  }
 
-exceptionTransports.push(
-  new (winston.transports.Console)({
-    json: (notProd === true) ? false : true,
-    timestamp: true,
+  return options.message || metaValues;
+}
+let loggingTransport = () => {
+  return new (winston.transports.Console)({
+    timestamp: () => {
+      return new Date().toISOString()
+    },
     colorize: true,
-    stringify: function stringify(obj) {
-      return JSON.stringify(obj);
+    formatter: (options) => {
+      return [
+        `[${config.appName}]`,
+        `[${options.level.toUpperCase()}]`,
+        options.timestamp(),
+        formatMessage(options)
+      ].join(' ');
     }
-  })
-);
+  });
+}
+
+loggingTransports.push(loggingTransport());
+exceptionTransports.push(loggingTransport());
 
 // Shut up mocha!
 if (config.env === 'test') {


### PR DESCRIPTION
Changed logging output so it's compatible with Kibana.

For example:

`[EVW Self Serve] [INFO] 2016-09-05T09:31:31.683Z status=200, method=GET, url=/update-journey-details/arrival-date, response_time=10, content_length=8617`

`[EVW Self Serve] [INFO] 2016-09-05T09:31:32.957Z looking up flight: number=KU0101, date=2016-09-09`

`[EVW Self Serve] [INFO] 2016-09-05T09:31:32.968Z flight service response for { number: 'KU0101', date: '2016-09-09' }: flights=[flightNumber=KU0101, departures=[port=DXB, country=AE], arrival=[port=LGW, date=2016-09-09, time=1845], body=[flightNumber=KU0101, arrivalDate=2016-09-09]]`