### PR TITLE
Feature/EVW-1977 UK departure details

### DIFF
--- a/acceptance_tests/features/smoke/update-journey-details.smoke.feature
+++ b/acceptance_tests/features/smoke/update-journey-details.smoke.feature
@@ -73,7 +73,7 @@ Scenario: Entering new flight details and correct flight found
   And the content list should contain
     """
     The new flight information I have entered is correct to the best of my knowledge and belief and is for my flight that lands in the UK.
-    On changing my flight details my old electronic visa waiver document will be invalid and I will not use it to try to enter the UK; if I do so I may be denied boarding or be refused entry at the UK border.
+    On changing my flight details my old electronic visa waiver document will be invalid and I will not use it to travel to the UK; if I do so I may be denied boarding or be refused entry at the UK border.
     If I have completed this for someone else I have their full agreement.
     """
   When I click id "Accept Declaration"

--- a/acceptance_tests/features/smoke/update-journey-details.smoke.feature
+++ b/acceptance_tests/features/smoke/update-journey-details.smoke.feature
@@ -37,7 +37,7 @@ Scenario: Entering new flight details and correct flight found
   And I continue
   # Check your answers page
   Then the page title should contain "Check your answers"
-  And the summary table should contain
+  And the "inbound-summary" table should contain
 
     """
     Departure airport

--- a/acceptance_tests/features/smoke/update-journey-details.smoke.feature
+++ b/acceptance_tests/features/smoke/update-journey-details.smoke.feature
@@ -35,6 +35,17 @@ Scenario: Entering new flight details and correct flight found
   And I enter a date "2 months" in the future into "Departure date"
   And I enter the time "12:15" into "Departure time"
   And I continue
+  # Return travel
+  Then I should be on the "Return travel" page of the "Update journey details" app
+  And the page title should contain "Have your travel details for your departure from the UK changed?"
+  And I select "Yes" for "Travel details changed"
+  And I continue
+  # UK departure
+  Then I should be on the "UK departure" page of the "Update journey details" app
+  And the page title should contain "Do you have your travel details for your departure from the UK?"
+  And I select "No" for "Know departure details"
+  And I select "1 to 3 months" for "UK duration"
+  And I continue
   # Check your answers page
   Then the page title should contain "Check your answers"
   And the "inbound-summary" table should contain

--- a/acceptance_tests/features/step_definitions/check-your-answers.js
+++ b/acceptance_tests/features/step_definitions/check-your-answers.js
@@ -3,13 +3,13 @@
 const moment = require('moment');
 
 const momentous = (quantity,  direction) => {
-  let action = direction === 'future' ? 'add' : 'subtract'
+  let action = direction === 'future' ? 'add' : 'subtract';
   let times = quantity.split(' ');
   let amount = Number(times[0]);
   let unit = times[1].slice(0,-1); //day/s month/s
 
   return moment()[action](amount, unit).format('DD/MM/YYYY'); // e.g. moment().add(2, 'months')
-}
+};
 
 const pullDate = (string) => {
   let matches = string.match(/^\${"([^"]*)" in the "([^"]*)"}$/);
@@ -22,15 +22,15 @@ const pullDate = (string) => {
   let direction = matches[2]; // "future" / "past"
 
   return momentous(quantity, direction)
-}
+};
 
 const d = (s) => pullDate(s);
 
 module.exports = function () {
 
-    this.Then(/^the summary table should contain$/, function (strings) {
+    this.Then(/^the "([^"]*)" table should contain$/, function (id, strings) {
         strings.split(/\n/).forEach( function (string) {
-            this.assert.containsText('#summary', d(string.trim()));
+            this.assert.containsText(`#${id}`, d(string.trim()));
         }, this);
     });
 

--- a/acceptance_tests/features/step_definitions/general.js
+++ b/acceptance_tests/features/step_definitions/general.js
@@ -9,7 +9,7 @@ const futureDate = (future) => {
     let amount = Number(times[0]);
     let unit = times[1].slice(0,-1); //day/s month/s
     return moment().add(amount, unit);
-}
+};
 module.exports = function () {
 
     this.When(/^I start the "([^"]*)" app$/, function (app) {
@@ -57,24 +57,24 @@ module.exports = function () {
     });
 
     this.When(/^I enter "([^"]*)" into "([^"]*)"$/, function (value, field) {
-        this.setValue('#'+urlise(field), value);
+        this.clearValue('#'+urlise(field)).setValue('#'+urlise(field), value);
     });
 
     this.When(/^I enter "([^"]*)" into "([^"]*)" class$/, function (value, field) {
-        this.setValue('.'+urlise(field), value);
+        this.clearValue('.'+urlise(field)).setValue('.'+urlise(field), value);
     });
 
     this.When(/^I enter the date "([^"]*)" into "([^"]*)"$/, function (date, field) {
         let d = date.split('-');
-        this.setValue('#'+urlise(field)+'-day', d[0]);
-        this.setValue('#'+urlise(field)+'-month', d[1]);
-        this.setValue('#'+urlise(field)+'-year', d[2]);
+        this.clearValue('#'+urlise(field)+'-day').setValue('#'+urlise(field)+'-day', d[0]);
+        this.clearValue('#'+urlise(field)+'-month').setValue('#'+urlise(field)+'-month', d[1]);
+        this.clearValue('#'+urlise(field)+'-year').setValue('#'+urlise(field)+'-year', d[2]);
     });
 
     this.When(/^I enter the time "([^"]*)" into "([^"]*)"$/, function (time, field) {
         let t = time.split(':');
-        this.setValue('#'+urlise(field)+'-hours', t[0]);
-        this.setValue('#'+urlise(field)+'-minutes', t[1]);
+        this.clearValue('#'+urlise(field)+'-hours').setValue('#'+urlise(field)+'-hours', t[0]);
+        this.clearValue('#'+urlise(field)+'-minutes').setValue('#'+urlise(field)+'-minutes', t[1]);
     });
 
     this.When(/^I enter a date "([^"]*)" in the future into "([^"]*)"$/, function (future, field) {
@@ -82,9 +82,9 @@ module.exports = function () {
         // console.log('future date', val.format('DD-MM-YYYY'));
         let target = urlise(field);
 
-        this.setValue('#' + target + '-day', val.format('DD'));
-        this.setValue('#' + target + '-month', val.format('MM'));
-        this.setValue('#' + target + '-year', val.format('YYYY'));
+        this.clearValue('#' + target + '-day').setValue('#' + target + '-day', val.format('DD'));
+        this.clearValue('#' + target + '-month').setValue('#' + target + '-month', val.format('MM'));
+        this.clearValue('#' + target + '-year').setValue('#' + target + '-year', val.format('YYYY'));
     });
 
     //And the "Arrival date" should contain a date "2 months" in the future
@@ -123,4 +123,11 @@ module.exports = function () {
         this.assert.containsText('body', value);
     });
 
+    this.When(/^I (?:click|select) "([^"]*)" for "([^"]*)"$/, function (value, field) {
+        this.click(`input[name=${urlise(field)}][value="${value}"]`);
+    });
+
+    this.When(/^I select "([^"]*)" from dropdown list for "([^"]*)"$/, function (value, selectList) {
+        this.click(`select[name="${urlise(selectList)}"] option[value="${value}"]`);
+    });
 };

--- a/acceptance_tests/features/update-journey-details.feature
+++ b/acceptance_tests/features/update-journey-details.feature
@@ -80,7 +80,7 @@ Scenario: Entering new flight details and correct flight found
   And the content list should contain
     """
     The new information I have entered is correct to the best of my knowledge and belief.
-    On changing my flight details my old electronic visa waiver document will be invalid and I will not use it to try to enter the UK; if I do so I may be denied boarding or be refused entry at the UK border.
+    On changing my flight details my old electronic visa waiver document will be invalid and I will not use it to travel to the UK; if I do so I may be denied boarding or be refused entry at the UK border.
     If I have completed this for someone else I have their full agreement.
     """
   When I click id "Accept Declaration"

--- a/acceptance_tests/features/update-journey-details.feature
+++ b/acceptance_tests/features/update-journey-details.feature
@@ -39,9 +39,16 @@ Scenario: Entering new flight details and correct flight found
   And I enter a date "2 months" in the future into "Departure date"
   And I enter the time "07:15" into "Departure time"
   And I continue
+  # UK departure
+  Then I should be on the "UK departure" page of the "Update journey details" app
+  And the page title should contain "Do you have your travel details for your departure from the UK?"
+  And I select "No" for "Know departure details"
+  And I select "1 to 3 months" for "UK duration"
+  And I select "No" for "UK visit more than once"
+  And I continue
   # Check your answers page
   Then the page title should contain "Check your answers"
-  And the summary table should contain
+  And the "inbound-summary" table should contain
     """
     Departure country
                       United Arab Emirates
@@ -59,6 +66,10 @@ Scenario: Entering new flight details and correct flight found
                       ${"2 months" in the "future"}
     Arrival time
                       18:45
+    Length of stay
+                      1 to 3 months
+    Further trips to UK planned within 3 months
+                      No
     """
   And I continue
   # Declaration page
@@ -66,7 +77,7 @@ Scenario: Entering new flight details and correct flight found
   And the page title should contain "Declaration"
   And the content list should contain
     """
-    The new flight information I have entered is correct to the best of my knowledge and belief and is for my flight that lands in the UK.
+    The new information I have entered is correct to the best of my knowledge and belief.
     On changing my flight details my old electronic visa waiver document will be invalid and I will not use it to try to enter the UK; if I do so I may be denied boarding or be refused entry at the UK border.
     If I have completed this for someone else I have their full agreement.
     """
@@ -75,6 +86,47 @@ Scenario: Entering new flight details and correct flight found
   Then I should be on the "Confirmation" page of the "Update journey details" app
   And the "header notice complete" should contain "Request received"
   And the reference number should be present
+
+  Scenario: Entering new outbound flight details
+
+    Given I start the Update journey details app
+    When I click "By plane"
+    And I continue
+    Then I should be on the "Flight number" page of the "Update journey details" app
+    And I enter "KU101" into "Flight number"
+    And I continue
+    # Arrival date page
+    Then I should be on the "Arrival date" page of the "Update journey details" app
+    And I enter a date "2 months" in the future into "Arrival date"
+    And I continue
+    # Is this your flight page
+    Then I should be on the "Is this your flight" page of the "Update journey details" app
+    And I click "Yes"
+    And I continue
+    # Departure date and time page
+    Then I should be on the "Departure date and time" page of the "Update journey details" app
+    And I enter a date "2 months" in the future into "Departure date"
+    And I enter the time "07:15" into "Departure time"
+    And I continue
+    # UK departure
+    Then I should be on the "UK departure" page of the "Update journey details" app
+    And I select "Yes" for "Know departure details"
+    And I enter "FL1001" into "UK departure travel number"
+    And I enter a date "2 months" in the future into "UK date of departure"
+    And I select "LGW" from dropdown list for "UK port of departure"
+    And I select "Yes" for "UK visit more than once"
+    And I continue
+    # Check your answers page
+    Then the page title should contain "Check your answers"
+    And the "outbound-summary" table should contain
+    """
+    Departure airport
+                      LGW
+    Departure date
+                      20/03/2017
+    Flight number
+                      FL1001
+    """
 
 Scenario: Multi-leg flight
 
@@ -102,9 +154,17 @@ Scenario: Multi-leg flight
   And I enter the time "07:15" into "Departure time"
   And I continue
 
+  # UK departure
+  Then I should be on the "UK departure" page of the "Update journey details" app
+  And the page title should contain "Do you have your travel details for your departure from the UK?"
+  And I select "No" for "Know departure details"
+  And I select "1 to 3 months" for "UK duration"
+  And I select "No" for "UK visit more than once"
+  And I continue
+
   # Check your answers page
   Then the page title should contain "Check your answers"
-  And the summary table should contain
+  And the "inbound-summary" table should contain
     """
     Departure country
                       Oman

--- a/acceptance_tests/features/update-journey-details.feature
+++ b/acceptance_tests/features/update-journey-details.feature
@@ -39,6 +39,11 @@ Scenario: Entering new flight details and correct flight found
   And I enter a date "2 months" in the future into "Departure date"
   And I enter the time "07:15" into "Departure time"
   And I continue
+  # Return travel
+  Then I should be on the "Return travel" page of the "Update journey details" app
+  And the page title should contain "Have your travel details for your departure from the UK changed?"
+  And I select "Yes" for "Travel details changed"
+  And I continue
   # UK departure
   Then I should be on the "UK departure" page of the "Update journey details" app
   And the page title should contain "Do you have your travel details for your departure from the UK?"
@@ -105,11 +110,16 @@ Scenario: Entering new flight details and correct flight found
     And I enter a date "2 months" in the future into "Departure date"
     And I enter the time "07:15" into "Departure time"
     And I continue
+    # Return travel
+    Then I should be on the "Return travel" page of the "Update journey details" app
+    And the page title should contain "Have your travel details for your departure from the UK changed?"
+    And I select "Yes" for "Travel details changed"
+    And I continue
     # UK departure
     Then I should be on the "UK departure" page of the "Update journey details" app
     And I select "Yes" for "Know departure details"
     And I enter "FL1001" into "UK departure travel number"
-    And I enter a date "2 months" in the future into "UK date of departure"
+    And I enter a date "3 months" in the future into "UK date of departure"
     And I select "LGW" from dropdown list for "UK port of departure"
     And I continue
     # Check your answers page
@@ -119,7 +129,7 @@ Scenario: Entering new flight details and correct flight found
     Departure airport
                       LGW
     Departure date
-                      20/03/2017
+                      ${"3 months" in the "future"}
     Flight number
                       FL1001
     """
@@ -150,11 +160,10 @@ Scenario: Multi-leg flight
   And I enter the time "07:15" into "Departure time"
   And I continue
 
-  # UK departure
-  Then I should be on the "UK departure" page of the "Update journey details" app
-  And the page title should contain "Do you have your travel details for your departure from the UK?"
-  And I select "No" for "Know departure details"
-  And I select "1 to 3 months" for "UK duration"
+  # Return travel
+  Then I should be on the "Return travel" page of the "Update journey details" app
+  And the page title should contain "Have your travel details for your departure from the UK changed?"
+  And I select "No" for "Travel details changed"
   And I continue
 
   # Check your answers page

--- a/acceptance_tests/features/update-journey-details.feature
+++ b/acceptance_tests/features/update-journey-details.feature
@@ -44,7 +44,6 @@ Scenario: Entering new flight details and correct flight found
   And the page title should contain "Do you have your travel details for your departure from the UK?"
   And I select "No" for "Know departure details"
   And I select "1 to 3 months" for "UK duration"
-  And I select "No" for "UK visit more than once"
   And I continue
   # Check your answers page
   Then the page title should contain "Check your answers"
@@ -68,8 +67,6 @@ Scenario: Entering new flight details and correct flight found
                       18:45
     Length of stay
                       1 to 3 months
-    Further trips to UK planned within 3 months
-                      No
     """
   And I continue
   # Declaration page
@@ -114,7 +111,6 @@ Scenario: Entering new flight details and correct flight found
     And I enter "FL1001" into "UK departure travel number"
     And I enter a date "2 months" in the future into "UK date of departure"
     And I select "LGW" from dropdown list for "UK port of departure"
-    And I select "Yes" for "UK visit more than once"
     And I continue
     # Check your answers page
     Then the page title should contain "Check your answers"
@@ -159,7 +155,6 @@ Scenario: Multi-leg flight
   And the page title should contain "Do you have your travel details for your departure from the UK?"
   And I select "No" for "Know departure details"
   And I select "1 to 3 months" for "UK duration"
-  And I select "No" for "UK visit more than once"
   And I continue
 
   # Check your answers page

--- a/acceptance_tests/features/update-journey-details.feature
+++ b/acceptance_tests/features/update-journey-details.feature
@@ -120,14 +120,14 @@ Scenario: Entering new flight details and correct flight found
     And I select "Yes" for "Know departure details"
     And I enter "FL1001" into "UK departure travel number"
     And I enter a date "3 months" in the future into "UK date of departure"
-    And I select "LGW" from dropdown list for "UK port of departure"
+    And I enter "London - Gatwick" into "UK port of departure_typeahead"
     And I continue
     # Check your answers page
     Then the page title should contain "Check your answers"
     And the "outbound-summary" table should contain
     """
     Departure airport
-                      LGW
+                      London - Gatwick
     Departure date
                       ${"3 months" in the "future"}
     Flight number

--- a/acceptance_tests/features/validation.feature
+++ b/acceptance_tests/features/validation.feature
@@ -95,6 +95,11 @@ Scenario: UK departure page validation
   And I enter the time "07:15" into "Departure time"
   And I continue
   # Return travel
+  And I continue
+  Then the validation summary should contain
+  """
+  Select one option
+  """
   And I select "Yes" for "Travel details changed"
   And I continue
   # UK departure

--- a/acceptance_tests/features/validation.feature
+++ b/acceptance_tests/features/validation.feature
@@ -94,6 +94,9 @@ Scenario: UK departure page validation
   And I enter a date "2 months" in the future into "Departure date"
   And I enter the time "07:15" into "Departure time"
   And I continue
+  # Return travel
+  And I select "Yes" for "Travel details changed"
+  And I continue
   # UK departure
   And I continue
   Then the validation summary should contain

--- a/acceptance_tests/features/validation.feature
+++ b/acceptance_tests/features/validation.feature
@@ -102,7 +102,6 @@ Scenario: UK departure page validation
   Select one option
   """
   When I select "No" for "Know departure details"
-  And I select "No" for "UK visit more than once"
   And I continue
   Then the validation summary should contain
   """

--- a/acceptance_tests/features/validation.feature
+++ b/acceptance_tests/features/validation.feature
@@ -75,3 +75,44 @@ Scenario: Not entering any details on the departure date and time page
     Enter a valid date
     Enter a valid time using the 24 hour clock, for example 09:45 or 21:45
     """
+
+Scenario: UK departure page validation
+
+  Given I start the Update journey details app
+  # How will you arrive page
+  When I click "By plane"
+  And I continue
+  And I enter "KU101" into "Flight number"
+  And I continue
+  # Arrival date page
+  And I enter a date "2 months" in the future into "Arrival date"
+  And I continue
+  # Is this your flight page
+  And I click "Yes"
+  And I continue
+  # Departure date and time
+  And I enter a date "2 months" in the future into "Departure date"
+  And I enter the time "07:15" into "Departure time"
+  And I continue
+  # UK departure
+  And I continue
+  Then the validation summary should contain
+  """
+  Select one option
+  Select one option
+  """
+  When I select "No" for "Know departure details"
+  And I select "No" for "UK visit more than once"
+  And I continue
+  Then the validation summary should contain
+  """
+  Select your length of stay in the UK
+  """
+  When I select "Yes" for "Know departure details"
+  And I continue
+  Then the validation summary should contain
+  """
+  Enter the flight number, train number or boat name that you will be leaving the UK on
+  Enter the date you are leaving the UK
+  Select one of the airports, sea ports or rail terminals from the list
+  """

--- a/apps/update-journey-details/controllers/check-your-answers.js
+++ b/apps/update-journey-details/controllers/check-your-answers.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const EvwBaseController = require('../../common/controllers/evw-base');
+
+module.exports = class CheckYourAnswersController extends EvwBaseController {
+  locals(req, res) {
+    return Object.assign({
+      knowDepartureDetailsYes: req.sessionModel.get('know-departure-details') === 'Yes',
+      knowDepartureDetailsNo: req.sessionModel.get('know-departure-details') === 'No'
+    }, super.locals.call(this, req, res));
+  }
+};

--- a/apps/update-journey-details/controllers/check-your-answers.js
+++ b/apps/update-journey-details/controllers/check-your-answers.js
@@ -1,12 +1,19 @@
 'use strict';
 
 const EvwBaseController = require('../../common/controllers/evw-base');
+const getTypeaheadValue = require('../../../lib/typeahead-options').getTypeaheadValue;
+const allAirportsPortsStations = require('../../../lib/typeahead-options').all;
 
 module.exports = class CheckYourAnswersController extends EvwBaseController {
   locals(req, res) {
+    let displayProps = {};
+    if (req.sessionModel.get('know-departure-details') === 'Yes') {
+      const portToDisplay = getTypeaheadValue(req.sessionModel.get('uk-port-of-departure'), allAirportsPortsStations);
+      displayProps.ukPortOfDepartureDisplay = portToDisplay;
+    }
     return Object.assign({
       knowDepartureDetailsYes: req.sessionModel.get('know-departure-details') === 'Yes',
       knowDepartureDetailsNo: req.sessionModel.get('know-departure-details') === 'No'
-    }, super.locals.call(this, req, res));
+    }, displayProps, super.locals.call(this, req, res));
   }
 };

--- a/apps/update-journey-details/controllers/confirmation.js
+++ b/apps/update-journey-details/controllers/confirmation.js
@@ -12,7 +12,32 @@ const schema = require('evw-schemas').evw.updateJourney.schema;
 const propMap = (model) => {
   let f = model.flightDetails;
 
-  return {
+  const getReturnJourneyDetails = () => {
+    let returnJourneyProps = {
+      haveDepartureFromUkDetailsChanged: model['travel-details-changed']
+    };
+    if (model['travel-details-changed'] === 'No') {
+      return returnJourneyProps;
+    }
+    Object.assign(returnJourneyProps, {
+      knowDepartureDetails: model['know-departure-details']
+    });
+    if (model['know-departure-details'] === 'No') {
+      Object.assign(returnJourneyProps, {
+        ukDuration: model['uk-duration']
+      });
+    }
+    if (model['know-departure-details'] === 'Yes') {
+      Object.assign(returnJourneyProps, {
+        departureTravel: model['uk-departure-travel-number'],
+        portOfDeparture: model['uk-port-of-departure'],
+        departureDate: model['uk-date-of-departure']
+      });
+    }
+   return returnJourneyProps;
+  };
+
+  return Object.assign({
     membershipNumber: model['evw-number'],
     token: model.token,
     arrivalTravel: f.flightNumber,
@@ -27,7 +52,7 @@ const propMap = (model) => {
     inwardDeparturePortCode: f.inwardDeparturePortPlaneCode,
     dateCreated: moment().format('YYYY-MM-DD hh:mm:ss'),
     flightDetailsCheck: 'Yes' // hard-coded until we implement un-happy path
-  }
+  }, getReturnJourneyDetails());
 };
 
 class ConfirmationController extends EvwBaseController {
@@ -71,7 +96,7 @@ class ConfirmationController extends EvwBaseController {
       req.context = {
         updateNumber: body.membershipNumber,
         emailAddress: body.currentDetails.contactDetails.emailAddress
-      }
+      };
 
       logger.info('application sent to integration service', body);
 

--- a/apps/update-journey-details/controllers/confirmation.js
+++ b/apps/update-journey-details/controllers/confirmation.js
@@ -8,6 +8,8 @@ const logger = require('../../../lib/logger');
 const Validator = require('jsonschema').Validator;
 const v = new Validator();
 const schema = require('evw-schemas').evw.updateJourney.schema;
+const getTypeaheadValue = require('../../../lib/typeahead-options').getTypeaheadValue;
+const allAirportsPortsStations = require('../../../lib/typeahead-options').all;
 
 const propMap = (model) => {
   let f = model.flightDetails;
@@ -30,7 +32,7 @@ const propMap = (model) => {
     if (model['know-departure-details'] === 'Yes') {
       Object.assign(returnJourneyProps, {
         departureTravel: model['uk-departure-travel-number'],
-        portOfDeparture: model['uk-port-of-departure'],
+        portOfDeparture: getTypeaheadValue(model['uk-port-of-departure'], allAirportsPortsStations),
         departureDate: model['uk-date-of-departure']
       });
     }

--- a/apps/update-journey-details/fields/index.js
+++ b/apps/update-journey-details/fields/index.js
@@ -8,5 +8,6 @@ module.exports = Object.assign(
   require('./choose-departure-airport'),
   require('./is-this-your-flight'),
   require('./departure-date-and-time'),
+  require('./uk-departure'),
   require('./declaration')
 );

--- a/apps/update-journey-details/fields/index.js
+++ b/apps/update-journey-details/fields/index.js
@@ -8,6 +8,7 @@ module.exports = Object.assign(
   require('./choose-departure-airport'),
   require('./is-this-your-flight'),
   require('./departure-date-and-time'),
+  require('./return-travel'),
   require('./uk-departure'),
   require('./declaration')
 );

--- a/apps/update-journey-details/fields/return-travel.js
+++ b/apps/update-journey-details/fields/return-travel.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  'travel-details-changed': {
+    validate: ['required'],
+    className: ['form-group'],
+    legend: {
+      className: 'visuallyhidden'
+    },
+    options: [{
+      value: 'Yes',
+      label: 'fields.travel-details-changed.options.yes.label'
+    }, {
+      value: 'No',
+      label: 'fields.travel-details-changed.options.no.label'
+    }]
+  }
+};

--- a/apps/update-journey-details/fields/uk-departure.js
+++ b/apps/update-journey-details/fields/uk-departure.js
@@ -83,16 +83,5 @@ module.exports = {
       field: 'know-departure-details',
       value: 'Yes'
     }
-  },
-  'uk-visit-more-than-once': {
-    validate: ['required'],
-    className: ['form-group', 'inline'],
-    options: [{
-      value: 'Yes',
-      label: 'fields.uk-visit-more-than-once.options.yes.label'
-    }, {
-      value: 'No',
-      label: 'fields.uk-visit-more-than-once.options.no.label'
-    }]
   }
 };

--- a/apps/update-journey-details/fields/uk-departure.js
+++ b/apps/update-journey-details/fields/uk-departure.js
@@ -83,5 +83,16 @@ module.exports = {
       field: 'know-departure-details',
       value: 'Yes'
     }
+  },
+  'uk-visit-more-than-once': {
+    validate: ['required'],
+    className: ['form-group', 'inline'],
+    options: [{
+      value: 'Yes',
+      label: 'fields.uk-visit-more-than-once.options.yes.label'
+    }, {
+      value: 'No',
+      label: 'fields.uk-visit-more-than-once.options.no.label'
+    }]
   }
 };

--- a/apps/update-journey-details/fields/uk-departure.js
+++ b/apps/update-journey-details/fields/uk-departure.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const moment = require('moment');
+const afterDate = require('../../../lib/validators').afterDate;
+const beforeDate = require('../../../lib/validators').beforeDate;
+
 module.exports = {
   'travel-details-changed': {
     validate: ['required'],
@@ -43,23 +47,26 @@ module.exports = {
     }
   },
   'uk-date-of-departure': {
-    type: ['date'],
-    validate: ['required'],
+    validate: ['required', 'date'],
+    validators: [{
+      type: beforeDate,
+      arguments: moment().add(48, 'hours').format('YYYY-MM-DD')
+    }, {
+      type: afterDate,
+      arguments: moment().add(6, 'months').format('YYYY-MM-DD')
+    }],
     dependent: {
       field: 'travel-details-changed',
       value: 'Yes'
     }
   },
   'uk-date-of-departure-day': {
-    validate: ['required', 'numeric'],
     label: 'fields.uk-date-of-departure-day.label'
   },
   'uk-date-of-departure-month': {
-    validate: ['required', 'numeric'],
     label: 'fields.uk-date-of-departure-month.label'
   },
   'uk-date-of-departure-year': {
-    validate: ['required', 'numeric'],
     label: 'fields.uk-date-of-departure-year.label'
   },
   'uk-port-of-departure': {

--- a/apps/update-journey-details/fields/uk-departure.js
+++ b/apps/update-journey-details/fields/uk-departure.js
@@ -3,6 +3,16 @@
 const moment = require('moment');
 const afterDate = require('../../../lib/validators').afterDate;
 const beforeDate = require('../../../lib/validators').beforeDate;
+const typeaheadOptions = require('../../../lib/typeahead-options');
+const ukPortOfDepartureOptions = typeaheadOptions.britishAirports({prependEmpty: false})
+  .concat(typeaheadOptions.britishPorts({prependEmpty: false}))
+  .concat(typeaheadOptions.britishStations({prependEmpty: false}));
+
+ukPortOfDepartureOptions.unshift({
+  label: 'notranslate.',
+  value: ''
+});
+
 
 module.exports = {
   'know-departure-details': {
@@ -71,14 +81,8 @@ module.exports = {
   },
   'uk-port-of-departure': {
     validate: ['required', {type: 'maxlength', arguments: '95'}],
-    className: ['form-group'],
-    options: [{
-      label: '',
-      value: ''
-    }, {
-      value: 'LGW',
-      label: 'London - Gatwick'
-    }],
+    className: ['typeahead'],
+    options: ukPortOfDepartureOptions,
     dependent: {
       field: 'know-departure-details',
       value: 'Yes'

--- a/apps/update-journey-details/fields/uk-departure.js
+++ b/apps/update-journey-details/fields/uk-departure.js
@@ -5,7 +5,7 @@ const afterDate = require('../../../lib/validators').afterDate;
 const beforeDate = require('../../../lib/validators').beforeDate;
 
 module.exports = {
-  'travel-details-changed': {
+  'know-departure-details': {
     validate: ['required'],
     className: ['form-group'],
     legend: {
@@ -13,12 +13,12 @@ module.exports = {
     },
     options: [{
       value: 'Yes',
-      label: 'fields.travel-details-changed.options.yes.label',
-      toggle: 'travel-details-changed-yes-div'
+      label: 'fields.know-departure-details.options.yes.label',
+      toggle: 'know-departure-details-yes-div'
     }, {
       value: 'No',
-      label: 'fields.travel-details-changed.options.no.label',
-      toggle: 'travel-details-changed-no-div'
+      label: 'fields.know-departure-details.options.no.label',
+      toggle: 'know-departure-details-no-div'
     }]
   },
   'uk-duration': {
@@ -35,14 +35,14 @@ module.exports = {
       label: 'fields.uk-duration.options.three-to-six-months.label'
     }],
     dependent: {
-      field: 'travel-details-changed',
+      field: 'know-departure-details',
       value: 'No'
     }
   },
   'uk-departure-travel-number': {
     validate: ['required', {type: 'maxlength', arguments: '30'}],
     dependent: {
-      field: 'travel-details-changed',
+      field: 'know-departure-details',
       value: 'Yes'
     }
   },
@@ -56,7 +56,7 @@ module.exports = {
       arguments: moment().add(6, 'months').format('YYYY-MM-DD')
     }],
     dependent: {
-      field: 'travel-details-changed',
+      field: 'know-departure-details',
       value: 'Yes'
     }
   },
@@ -80,7 +80,7 @@ module.exports = {
       label: 'London - Gatwick'
     }],
     dependent: {
-      field: 'travel-details-changed',
+      field: 'know-departure-details',
       value: 'Yes'
     }
   }

--- a/apps/update-journey-details/fields/uk-departure.js
+++ b/apps/update-journey-details/fields/uk-departure.js
@@ -9,7 +9,7 @@ const ukPortOfDepartureOptions = typeaheadOptions.britishAirports({prependEmpty:
   .concat(typeaheadOptions.britishStations({prependEmpty: false}));
 
 ukPortOfDepartureOptions.unshift({
-  label: 'notranslate.',
+  label: '',
   value: ''
 });
 

--- a/apps/update-journey-details/fields/uk-departure.js
+++ b/apps/update-journey-details/fields/uk-departure.js
@@ -1,0 +1,80 @@
+'use strict';
+
+module.exports = {
+  'travel-details-changed': {
+    validate: ['required'],
+    className: ['form-group'],
+    legend: {
+      className: 'visuallyhidden'
+    },
+    options: [{
+      value: 'Yes',
+      label: 'fields.travel-details-changed.options.yes.label',
+      toggle: 'travel-details-changed-yes-div'
+    }, {
+      value: 'No',
+      label: 'fields.travel-details-changed.options.no.label',
+      toggle: 'travel-details-changed-no-div'
+    }]
+  },
+  'uk-duration': {
+    validate: ['required'],
+    className: ['form-group'],
+    options: [{
+      value: 'Less than 1 month',
+      label: 'fields.uk-duration.options.less-than-one-month.label'
+    }, {
+      value: '1 to 3 months',
+      label: 'fields.uk-duration.options.one-to-three-months.label'
+    }, {
+      value: '3 to 6 months',
+      label: 'fields.uk-duration.options.three-to-six-months.label'
+    }],
+    dependent: {
+      field: 'travel-details-changed',
+      value: 'No'
+    }
+  },
+  'uk-departure-travel-number': {
+    validate: ['required', {type: 'maxlength', arguments: '30'}],
+    dependent: {
+      field: 'travel-details-changed',
+      value: 'Yes'
+    }
+  },
+  'uk-date-of-departure': {
+    type: ['date'],
+    validate: ['required'],
+    dependent: {
+      field: 'travel-details-changed',
+      value: 'Yes'
+    }
+  },
+  'uk-date-of-departure-day': {
+    validate: ['required', 'numeric'],
+    label: 'fields.uk-date-of-departure-day.label'
+  },
+  'uk-date-of-departure-month': {
+    validate: ['required', 'numeric'],
+    label: 'fields.uk-date-of-departure-month.label'
+  },
+  'uk-date-of-departure-year': {
+    validate: ['required', 'numeric'],
+    label: 'fields.uk-date-of-departure-year.label'
+  },
+  'uk-port-of-departure': {
+    validate: ['required', {type: 'maxlength', arguments: '95'}],
+    className: ['form-group'],
+    options: [{
+      label: '',
+      value: ''
+    }, {
+      value: 'LGW',
+      label: 'London - Gatwick'
+    }],
+    dependent: {
+      field: 'travel-details-changed',
+      value: 'Yes'
+    }
+  }
+};

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -89,11 +89,26 @@ module.exports = {
       'departure-time-hours',
       'departure-time-minutes'
     ],
-    next: '/check-your-answers',
+    next: '/uk-departure',
     options: {
       dateKeys: ['departure-date'],
       timeKeys: ['departure-time']
     }
+  },
+  '/uk-departure': {
+    template: 'uk-departure',
+    controller: require('../common/controllers/evw-base'),
+    fields: [
+      'travel-details-changed',
+      'uk-duration',
+      'uk-departure-travel-number',
+      'uk-date-of-departure',
+      'uk-date-of-departure-day',
+      'uk-date-of-departure-month',
+      'uk-date-of-departure-year',
+      'uk-port-of-departure'
+    ],
+    next: '/check-your-answers'
   },
   '/check-your-answers': {
     template: 'check-your-answers.html',

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -106,7 +106,8 @@ module.exports = {
       'uk-date-of-departure-day',
       'uk-date-of-departure-month',
       'uk-date-of-departure-year',
-      'uk-port-of-departure'
+      'uk-port-of-departure',
+      'uk-visit-more-than-once'
     ],
     next: '/check-your-answers',
     options: {

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -108,7 +108,10 @@ module.exports = {
       'uk-date-of-departure-year',
       'uk-port-of-departure'
     ],
-    next: '/check-your-answers'
+    next: '/check-your-answers',
+    options: {
+      dateKeys: ['uk-date-of-departure']
+    }
   },
   '/check-your-answers': {
     template: 'check-your-answers.html',

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -106,8 +106,7 @@ module.exports = {
       'uk-date-of-departure-day',
       'uk-date-of-departure-month',
       'uk-date-of-departure-year',
-      'uk-port-of-departure',
-      'uk-visit-more-than-once'
+      'uk-port-of-departure'
     ],
     next: '/check-your-answers',
     options: {

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -99,7 +99,7 @@ module.exports = {
     template: 'uk-departure',
     controller: require('../common/controllers/evw-base'),
     fields: [
-      'travel-details-changed',
+      'know-departure-details',
       'uk-duration',
       'uk-departure-travel-number',
       'uk-date-of-departure',

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -115,7 +115,7 @@ module.exports = {
   },
   '/check-your-answers': {
     template: 'check-your-answers.html',
-    controller: require('../common/controllers/evw-base'),
+    controller: require('./controllers/check-your-answers'),
     next: '/declaration'
   },
   '/flight-not-found': {

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -89,11 +89,26 @@ module.exports = {
       'departure-time-hours',
       'departure-time-minutes'
     ],
-    next: '/uk-departure',
+    next: '/return-travel',
     options: {
       dateKeys: ['departure-date'],
       timeKeys: ['departure-time']
     }
+  },
+  '/return-travel': {
+    template: 'return-travel',
+    controller: require('../common/controllers/evw-base'),
+    fields: [
+      'travel-details-changed'
+    ],
+    next: '/check-your-answers',
+    forks: [{
+      target: '/uk-departure',
+      condition: {
+        field: 'travel-details-changed',
+        value: 'Yes'
+      }
+    }]
   },
   '/uk-departure': {
     template: 'uk-departure',

--- a/apps/update-journey-details/translations/src/en/fields.json
+++ b/apps/update-journey-details/translations/src/en/fields.json
@@ -77,5 +77,50 @@
   },
   "accept-declaration": {
     "label": "I understand and agree with the above"
+  },
+  "travel-details-changed": {
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "uk-duration": {
+    "legend": "How long are you staying in the UK for?",
+    "options": {
+      "less-than-one-month": {
+        "label": "Less than 1 month"
+      },
+      "one-to-three-months": {
+        "label": "1 to 3 months"
+      },
+      "three-to-six-months": {
+        "label": "3 to 6 months"
+      }
+    }
+  },
+  "uk-departure-travel-number": {
+    "label": "Enter the flight number, train number or boat name for your departure from the UK",
+    "hint": "The details will be on your travel documents"
+  },
+  "uk-date-of-departure": {
+    "legend": "What date will you be departing the UK?",
+    "hint": "For example, 31 3 2017"
+  },
+  "uk-date-of-departure-day": {
+    "label": "Day"
+  },
+  "uk-date-of-departure-month": {
+    "label": "Month"
+  },
+  "uk-date-of-departure-year": {
+    "label": "Year"
+  },
+  "uk-port-of-departure": {
+    "label": "What airport, train station or port are you leaving the UK from?",
+    "hint": "The details will be on your travel documents"
   }
 }

--- a/apps/update-journey-details/translations/src/en/fields.json
+++ b/apps/update-journey-details/translations/src/en/fields.json
@@ -117,7 +117,7 @@
     "hint": "The details will be on your travel documents"
   },
   "uk-date-of-departure": {
-    "legend": "What date will you be departing the UK?",
+    "legend": "What date will you be leaving the UK?",
     "hint": "For example, 31 3 2017"
   },
   "uk-date-of-departure-day": {

--- a/apps/update-journey-details/translations/src/en/fields.json
+++ b/apps/update-journey-details/translations/src/en/fields.json
@@ -122,16 +122,5 @@
   "uk-port-of-departure": {
     "label": "What airport, train station or port are you leaving the UK from?",
     "hint": "The details will be on your travel documents"
-  },
-  "uk-visit-more-than-once": {
-    "legend": "Do you plan to make more than one trip to the UK during the next 3 months?",
-    "options": {
-      "yes": {
-        "label": "Yes"
-      },
-      "no": {
-        "label": "No"
-      }
-    }
   }
 }

--- a/apps/update-journey-details/translations/src/en/fields.json
+++ b/apps/update-journey-details/translations/src/en/fields.json
@@ -78,6 +78,16 @@
   "accept-declaration": {
     "label": "I understand and agree with the above"
   },
+  "travel-details-changed": {
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
   "know-departure-details": {
     "options": {
       "yes": {

--- a/apps/update-journey-details/translations/src/en/fields.json
+++ b/apps/update-journey-details/translations/src/en/fields.json
@@ -122,5 +122,16 @@
   "uk-port-of-departure": {
     "label": "What airport, train station or port are you leaving the UK from?",
     "hint": "The details will be on your travel documents"
+  },
+  "uk-visit-more-than-once": {
+    "legend": "Do you plan to make more than one trip to the UK during the next 3 months?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
   }
 }

--- a/apps/update-journey-details/translations/src/en/fields.json
+++ b/apps/update-journey-details/translations/src/en/fields.json
@@ -78,7 +78,7 @@
   "accept-declaration": {
     "label": "I understand and agree with the above"
   },
-  "travel-details-changed": {
+  "know-departure-details": {
     "options": {
       "yes": {
         "label": "Yes"

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -81,6 +81,7 @@
       "arrival-date": "Arrival date",
       "arrival-time": "Arrival time",
       "uk-duration": "Length of stay",
+      "uk-visit-more-than-once": "Further trips to UK planned within 3 months",
       "uk-port-of-departure": "Departure airport",
       "uk-date-of-departure": "Departure date",
       "uk-departure-travel-number": "Flight number"

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -63,6 +63,9 @@
   "departure-date-and-time": {
     "header": "Your journey to the UK"
   },
+  "uk-departure": {
+    "header": "Have your travel details for your departure from the UK changed?"
+  },
   "check-your-answers": {
     "header": "Check your answers",
     "notice": "Please check your new flight details and correct them if necessary",

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -69,6 +69,8 @@
   "check-your-answers": {
     "header": "Check your answers",
     "notice": "Please check your new flight details and correct them if necessary",
+    "journey-to-uk-title": "Your journey to the UK",
+    "journey-from-uk-title": "Your journey from the UK",
     "table": {
       "departure-country": "Departure country",
       "departure-airport": "Departure airport",
@@ -77,7 +79,10 @@
       "flight-number": "Flight number",
       "arrival-airport": "Arrival airport",
       "arrival-date": "Arrival date",
-      "arrival-time": "Arrival time"
+      "arrival-time": "Arrival time",
+      "uk-port-of-departure": "Departure airport",
+      "uk-date-of-departure": "Departure date",
+      "uk-departure-travel-number": "Flight number"
     }
   },
   "flight-not-found": {

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -80,6 +80,7 @@
       "arrival-airport": "Arrival airport",
       "arrival-date": "Arrival date",
       "arrival-time": "Arrival time",
+      "uk-duration": "Length of stay",
       "uk-port-of-departure": "Departure airport",
       "uk-date-of-departure": "Departure date",
       "uk-departure-travel-number": "Flight number"

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -63,6 +63,9 @@
   "departure-date-and-time": {
     "header": "Your journey to the UK"
   },
+  "return-travel": {
+    "header": "Have you travel details for your departure from the UK changed?"
+  },
   "uk-departure": {
     "header": "Do you have your travel details for your departure from the UK?"
   },

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -116,7 +116,7 @@
     "header": "Declaration",
     "content": "I confirm that:",
     "confirmation-1": "The new information I have entered is correct to the best of my knowledge and belief.",
-    "confirmation-2": "On changing my flight details my old electronic visa waiver document will be invalid and I will not use it to try to enter the UK; if I do so I may be denied boarding or be refused entry at the UK border.",
+    "confirmation-2": "On changing my flight details my old electronic visa waiver document will be invalid and I will not use it to travel to the UK; if I do so I may be denied boarding or be refused entry at the UK border.",
     "confirmation-3": "If I have completed this for someone else I have their full agreement."
   },
   "confirmation": {

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -81,7 +81,6 @@
       "arrival-date": "Arrival date",
       "arrival-time": "Arrival time",
       "uk-duration": "Length of stay",
-      "uk-visit-more-than-once": "Further trips to UK planned within 3 months",
       "uk-port-of-departure": "Departure airport",
       "uk-date-of-departure": "Departure date",
       "uk-departure-travel-number": "Flight number"

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -64,7 +64,7 @@
     "header": "Your journey to the UK"
   },
   "return-travel": {
-    "header": "Have you travel details for your departure from the UK changed?"
+    "header": "Have your travel details for your departure from the UK changed?"
   },
   "uk-departure": {
     "header": "Do you have your travel details for your departure from the UK?"

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -64,7 +64,7 @@
     "header": "Your journey to the UK"
   },
   "uk-departure": {
-    "header": "Have your travel details for your departure from the UK changed?"
+    "header": "Do you have your travel details for your departure from the UK?"
   },
   "check-your-answers": {
     "header": "Check your answers",

--- a/apps/update-journey-details/translations/src/en/pages.json
+++ b/apps/update-journey-details/translations/src/en/pages.json
@@ -112,7 +112,7 @@
   "declaration": {
     "header": "Declaration",
     "content": "I confirm that:",
-    "confirmation-1": "The new flight information I have entered is correct to the best of my knowledge and belief and is for my flight that lands in the UK.",
+    "confirmation-1": "The new information I have entered is correct to the best of my knowledge and belief.",
     "confirmation-2": "On changing my flight details my old electronic visa waiver document will be invalid and I will not use it to try to enter the UK; if I do so I may be denied boarding or be refused entry at the UK border.",
     "confirmation-3": "If I have completed this for someone else I have their full agreement."
   },

--- a/apps/update-journey-details/translations/src/en/validation.json
+++ b/apps/update-journey-details/translations/src/en/validation.json
@@ -49,9 +49,9 @@
   },
   "uk-date-of-departure": {
     "required": "Enter the date you are leaving the UK",
-    "invalid": "Enter a valid date",
-    "in-past": "The date you leave the UK cannot be in the past",
-    "in-future": "Date of departure cannot be more than 6 months after you enter the UK"
+    "date": "Enter a valid date",
+    "beforeDate": "The date you leave the UK cannot be in the past",
+    "afterDate": "Date of departure cannot be more than 6 months after you enter the UK"
   },
   "uk-port-of-departure": {
     "required": "Select one of the airports, sea ports or rail terminals from the list"

--- a/apps/update-journey-details/translations/src/en/validation.json
+++ b/apps/update-journey-details/translations/src/en/validation.json
@@ -37,5 +37,23 @@
   },
   "departures": {
     "required": "Please choose a departure airport"
+  },
+  "travel-details-changed": {
+    "required": "Select one option"
+  },
+  "uk-duration": {
+    "required": "Select your length of stay in the UK"
+  },
+  "uk-departure-travel-number": {
+    "required": "Enter the flight number, train number or boat name that you will be leaving the UK on"
+  },
+  "uk-date-of-departure": {
+    "required": "Enter the date you are leaving the UK",
+    "invalid": "Enter a valid date",
+    "in-past": "The date you leave the UK cannot be in the past",
+    "in-future": "Date of departure cannot be more than 6 months after you enter the UK"
+  },
+  "uk-port-of-departure": {
+    "required": "Select one of the airports, sea ports or rail terminals from the list"
   }
 }

--- a/apps/update-journey-details/translations/src/en/validation.json
+++ b/apps/update-journey-details/translations/src/en/validation.json
@@ -38,6 +38,9 @@
   "departures": {
     "required": "Please choose a departure airport"
   },
+  "travel-details-changed": {
+    "required": "Select one option"
+  },
   "know-departure-details": {
     "required": "Select one option"
   },

--- a/apps/update-journey-details/translations/src/en/validation.json
+++ b/apps/update-journey-details/translations/src/en/validation.json
@@ -55,8 +55,5 @@
   },
   "uk-port-of-departure": {
     "required": "Select one of the airports, sea ports or rail terminals from the list"
-  },
-  "uk-visit-more-than-once": {
-    "required": "Select one option"
   }
 }

--- a/apps/update-journey-details/translations/src/en/validation.json
+++ b/apps/update-journey-details/translations/src/en/validation.json
@@ -38,7 +38,7 @@
   "departures": {
     "required": "Please choose a departure airport"
   },
-  "travel-details-changed": {
+  "know-departure-details": {
     "required": "Select one option"
   },
   "uk-duration": {

--- a/apps/update-journey-details/translations/src/en/validation.json
+++ b/apps/update-journey-details/translations/src/en/validation.json
@@ -55,5 +55,8 @@
   },
   "uk-port-of-departure": {
     "required": "Select one of the airports, sea ports or rail terminals from the list"
+  },
+  "uk-visit-more-than-once": {
+    "required": "Select one option"
   }
 }

--- a/apps/update-journey-details/views/check-your-answers.html
+++ b/apps/update-journey-details/views/check-your-answers.html
@@ -102,7 +102,7 @@
             <tr>
                 <td>{{#t}}pages.check-your-answers.table.uk-port-of-departure{{/t}}</td>
                 <td class="data-port-of-departure bold">
-                    {{values.uk-port-of-departure}}
+                    {{ukPortOfDepartureDisplay}}
                 </td>
                 <td><a href="uk-departure#edit/uk-port-of-departure" class="button">{{#t}}buttons.change{{/t}}</a></td>
             </tr>

--- a/apps/update-journey-details/views/check-your-answers.html
+++ b/apps/update-journey-details/views/check-your-answers.html
@@ -81,36 +81,48 @@
             </td>
             <td><a href="arrival-date#edit/arrival-time" class="button">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
+        {{#knowDepartureDetailsNo}}
+            <tr>
+                <td>{{#t}}pages.check-your-answers.table.uk-duration{{/t}}</td>
+                <td class="data-uk-duration bold">
+                    {{values.uk-duration}}
+                </td>
+                <td><a href="uk-departure#edit/uk-duration" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            </tr>
+        {{/knowDepartureDetailsNo}}
     </tbody>
 </table>
 
-<h2>{{#t}}pages.check-your-answers.journey-from-uk-title{{/t}}</h2>
-<table class="table-details">
-    <thead></thead>
-    <tbody>
-        <tr>
-            <td>{{#t}}pages.check-your-answers.table.uk-port-of-departure{{/t}}</td>
-            <td class="data-port-of-departure bold">
-                {{values.uk-port-of-departure}}
-            </td>
-            <td><a href="uk-departure#edit/uk-port-of-departure" class="button">{{#t}}buttons.change{{/t}}</a></td>
-        </tr>
-        <tr>
-            <td>{{#t}}pages.check-your-answers.table.uk-date-of-departure{{/t}}</td>
-            <td class="data-uk-date-of-departure bold">
-                {{values.uk-date-of-departure}}
-            </td>
-            <td><a href="uk-departure#edit/uk-date-of-departure" class="button">{{#t}}buttons.change{{/t}}</a></td>
-        </tr>
-        <tr>
-            <td>{{#t}}pages.check-your-answers.table.uk-departure-travel-number{{/t}}</td>
-            <td class="data-uk-departure-travel-number bold">
-                {{values.uk-departure-travel-number}}
-            </td>
-            <td><a href="uk-departure#edit/uk-departure-travel-number" class="button">{{#t}}buttons.change{{/t}}</a></td>
-        </tr>
-    </tbody>
-</table>
+
+{{#knowDepartureDetailsYes}}
+    <h2>{{#t}}pages.check-your-answers.journey-from-uk-title{{/t}}</h2>
+    <table class="table-details">
+        <thead></thead>
+        <tbody>
+            <tr>
+                <td>{{#t}}pages.check-your-answers.table.uk-port-of-departure{{/t}}</td>
+                <td class="data-port-of-departure bold">
+                    {{values.uk-port-of-departure}}
+                </td>
+                <td><a href="uk-departure#edit/uk-port-of-departure" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            </tr>
+            <tr>
+                <td>{{#t}}pages.check-your-answers.table.uk-date-of-departure{{/t}}</td>
+                <td class="data-uk-date-of-departure bold">
+                    {{values.uk-date-of-departure}}
+                </td>
+                <td><a href="uk-departure#edit/uk-date-of-departure" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            </tr>
+            <tr>
+                <td>{{#t}}pages.check-your-answers.table.uk-departure-travel-number{{/t}}</td>
+                <td class="data-uk-departure-travel-number bold">
+                    {{values.uk-departure-travel-number}}
+                </td>
+                <td><a href="uk-departure#edit/uk-departure-travel-number" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            </tr>
+        </tbody>
+    </table>
+{{/knowDepartureDetailsYes}}
 
 <p>
     <br>

--- a/apps/update-journey-details/views/check-your-answers.html
+++ b/apps/update-journey-details/views/check-your-answers.html
@@ -22,7 +22,7 @@
 <p>{{#t}}pages.check-your-answers.notice{{/t}}</p>
 
 <h2>{{#t}}pages.check-your-answers.journey-to-uk-title{{/t}}</h2>
-<table class="table-details">
+<table id="inbound-summary" class="table-details">
     <thead></thead>
     <tbody>
         <tr>
@@ -103,7 +103,7 @@
 
 {{#knowDepartureDetailsYes}}
     <h2>{{#t}}pages.check-your-answers.journey-from-uk-title{{/t}}</h2>
-    <table class="table-details">
+    <table id="outbound-summary" class="table-details">
         <thead></thead>
         <tbody>
             <tr>
@@ -116,7 +116,7 @@
             <tr>
                 <td>{{#t}}pages.check-your-answers.table.uk-date-of-departure{{/t}}</td>
                 <td class="data-uk-date-of-departure bold">
-                    {{values.uk-date-of-departure}}
+                    {{values.uk-date-of-departure-formatted}}
                 </td>
                 <td><a href="uk-departure#edit/uk-date-of-departure" class="button">{{#t}}buttons.change{{/t}}</a></td>
             </tr>

--- a/apps/update-journey-details/views/check-your-answers.html
+++ b/apps/update-journey-details/views/check-your-answers.html
@@ -90,6 +90,13 @@
                 <td><a href="uk-departure#edit/uk-duration" class="button">{{#t}}buttons.change{{/t}}</a></td>
             </tr>
         {{/knowDepartureDetailsNo}}
+        <tr>
+            <td>{{#t}}pages.check-your-answers.table.uk-visit-more-than-once{{/t}}</td>
+            <td class="data-uk-visit-more-than-once bold">
+                {{values.uk-visit-more-than-once}}
+            </td>
+            <td><a href="uk-departure#edit/uk-visit-more-than-once" class="button">{{#t}}buttons.change{{/t}}</a></td>
+        </tr>
     </tbody>
 </table>
 

--- a/apps/update-journey-details/views/check-your-answers.html
+++ b/apps/update-journey-details/views/check-your-answers.html
@@ -90,13 +90,6 @@
                 <td><a href="uk-departure#edit/uk-duration" class="button">{{#t}}buttons.change{{/t}}</a></td>
             </tr>
         {{/knowDepartureDetailsNo}}
-        <tr>
-            <td>{{#t}}pages.check-your-answers.table.uk-visit-more-than-once{{/t}}</td>
-            <td class="data-uk-visit-more-than-once bold">
-                {{values.uk-visit-more-than-once}}
-            </td>
-            <td><a href="uk-departure#edit/uk-visit-more-than-once" class="button">{{#t}}buttons.change{{/t}}</a></td>
-        </tr>
     </tbody>
 </table>
 

--- a/apps/update-journey-details/views/check-your-answers.html
+++ b/apps/update-journey-details/views/check-your-answers.html
@@ -19,9 +19,10 @@
 {{$form}}
 
 <h1 class='heading-large'>{{#t}}pages.check-your-answers.header{{/t}}</h1>
-<p class="bold">{{#t}}pages.check-your-answers.notice{{/t}}</p>
+<p>{{#t}}pages.check-your-answers.notice{{/t}}</p>
 
-<table id="summary" class="table-details">
+<h2>{{#t}}pages.check-your-answers.journey-to-uk-title{{/t}}</h2>
+<table class="table-details">
     <thead></thead>
     <tbody>
         <tr>
@@ -29,28 +30,28 @@
             <td class="data-departure-country bold">
                 {{values.flightDetails.inwardDepartureCountryPlane}}
             </td>
-            <td><a href="flight-number#edit/flight-number" class="button" id="">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="flight-number#edit/flight-number" class="button">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
         <tr>
             <td>{{#t}}pages.check-your-answers.table.departure-airport{{/t}}</td>
             <td class="data-departure-airport bold">
                 {{values.flightDetails.departureAirport}}
             </td>
-            <td><a href="flight-number#edit/flight-number" class="button" id="">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="flight-number#edit/flight-number" class="button">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
         <tr>
             <td>{{#t}}pages.check-your-answers.table.departure-date{{/t}}</td>
             <td class="data-departure-date bold">
                 {{values.departure-date-formatted}}
             </td>
-            <td><a href="departure-date-and-time#edit/departure-date" class="button" id="">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="departure-date-and-time#edit/departure-date" class="button">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
         <tr>
             <td>{{#t}}pages.check-your-answers.table.departure-time{{/t}}</td>
             <td class="data-departure-time bold">
                 {{values.departure-time}}
             </td>
-            <td><a href="departure-date-and-time#edit/departure-time" class="button" id="">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="departure-date-and-time#edit/departure-time" class="button">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
         <tr>
             <td>{{#t}}pages.check-your-answers.table.flight-number{{/t}}</td>
@@ -64,24 +65,53 @@
             <td class="data-arrival-airport bold">
                 {{values.flightDetails.arrivalAirport}}
             </td>
-            <td><a href="flight-number#edit/flight-number" class="button" id="">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="flight-number#edit/flight-number" class="button">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
         <tr>
             <td>{{#t}}pages.check-your-answers.table.arrival-date{{/t}}</td>
             <td class="data-arrival-date bold">
                 {{values.flightDetails.arrivalDate}}
             </td>
-            <td><a href="arrival-date#edit/arrival-date" class="button" id="">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="arrival-date#edit/arrival-date" class="button">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
         <tr>
             <td>{{#t}}pages.check-your-answers.table.arrival-time{{/t}}</td>
             <td class="data-arrival-time bold">
                 {{values.flightDetails.arrivalTime}}
             </td>
-            <td><a href="arrival-date#edit/arrival-time" class="button" id="">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="arrival-date#edit/arrival-time" class="button">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
     </tbody>
 </table>
+
+<h2>{{#t}}pages.check-your-answers.journey-from-uk-title{{/t}}</h2>
+<table class="table-details">
+    <thead></thead>
+    <tbody>
+        <tr>
+            <td>{{#t}}pages.check-your-answers.table.uk-port-of-departure{{/t}}</td>
+            <td class="data-port-of-departure bold">
+                {{values.uk-port-of-departure}}
+            </td>
+            <td><a href="uk-departure#edit/uk-port-of-departure" class="button">{{#t}}buttons.change{{/t}}</a></td>
+        </tr>
+        <tr>
+            <td>{{#t}}pages.check-your-answers.table.uk-date-of-departure{{/t}}</td>
+            <td class="data-uk-date-of-departure bold">
+                {{values.uk-date-of-departure}}
+            </td>
+            <td><a href="uk-departure#edit/uk-date-of-departure" class="button">{{#t}}buttons.change{{/t}}</a></td>
+        </tr>
+        <tr>
+            <td>{{#t}}pages.check-your-answers.table.uk-departure-travel-number{{/t}}</td>
+            <td class="data-uk-departure-travel-number bold">
+                {{values.uk-departure-travel-number}}
+            </td>
+            <td><a href="uk-departure#edit/uk-departure-travel-number" class="button">{{#t}}buttons.change{{/t}}</a></td>
+        </tr>
+    </tbody>
+</table>
+
 <p>
     <br>
     {{#input-submit}}Confirm submission{{/input-submit}}

--- a/apps/update-journey-details/views/return-travel.html
+++ b/apps/update-journey-details/views/return-travel.html
@@ -1,0 +1,34 @@
+{{<layout}}
+
+{{$journeyHeader}}
+{{#t}}journey.header{{/t}}
+{{/journeyHeader}}
+
+{{$validationSummary}}
+{{> partials-validation-summary}}
+{{/validationSummary}}
+
+{{$propositionHeader}}
+{{> partials-navigation}}
+{{/propositionHeader}}
+
+{{$content}}
+<header>
+    <h1 class="heading-large">{{#t}}pages.return-travel.header{{/t}}</h1>
+</header>
+
+{{<partials-form}}
+
+{{$form}}
+
+  {{#radio-group}}travel-details-changed{{/radio-group}}
+
+  {{#input-submit}}continue{{/input-submit}}
+
+{{/form}}
+
+{{/partials-form}}
+
+{{/content}}
+
+{{/layout}}

--- a/apps/update-journey-details/views/uk-departure.html
+++ b/apps/update-journey-details/views/uk-departure.html
@@ -44,8 +44,6 @@
     {{#radio-group}}uk-duration{{/radio-group}}
   </div>
 
-  {{#radio-group}}uk-visit-more-than-once{{/radio-group}}
-
   {{#input-submit}}continue{{/input-submit}}
 
 {{/form}}

--- a/apps/update-journey-details/views/uk-departure.html
+++ b/apps/update-journey-details/views/uk-departure.html
@@ -21,9 +21,9 @@
 
 {{$form}}
 
-  {{#radio-group}}travel-details-changed{{/radio-group}}
+  {{#radio-group}}know-departure-details{{/radio-group}}
 
-  <div id="travel-details-changed-yes-div" class="panel-indent">
+  <div id="know-departure-details-yes-div" class="panel-indent">
     {{#input-text}}uk-departure-travel-number{{/input-text}}
 
     <fieldset id="uk-date-of-departure-group" class="{{#errors.uk-date-of-departure}}validation-error{{/errors.uk-date-of-departure}} form-group">
@@ -40,7 +40,7 @@
     {{#select}}uk-port-of-departure{{/select}}
   </div>
 
-  <div id="travel-details-changed-no-div" class="panel-indent">
+  <div id="know-departure-details-no-div" class="panel-indent">
     {{#radio-group}}uk-duration{{/radio-group}}
   </div>
 

--- a/apps/update-journey-details/views/uk-departure.html
+++ b/apps/update-journey-details/views/uk-departure.html
@@ -1,0 +1,55 @@
+{{<layout}}
+
+{{$journeyHeader}}
+{{#t}}journey.header{{/t}}
+{{/journeyHeader}}
+
+{{$validationSummary}}
+{{> partials-validation-summary}}
+{{/validationSummary}}
+
+{{$propositionHeader}}
+{{> partials-navigation}}
+{{/propositionHeader}}
+
+{{$content}}
+<header>
+    <h1 class="heading-large">{{#t}}pages.uk-departure.header{{/t}}</h1>
+</header>
+
+{{<partials-form}}
+
+{{$form}}
+
+  {{#radio-group}}travel-details-changed{{/radio-group}}
+
+  <div id="travel-details-changed-yes-div" class="panel-indent">
+    {{#input-text}}uk-departure-travel-number{{/input-text}}
+
+    <fieldset id="uk-date-of-departure-group" class="{{#errors.uk-date-of-departure}}validation-error{{/errors.uk-date-of-departure}} form-group">
+      <legend class="form-label-bold">{{#t}}fields.uk-date-of-departure.legend{{/t}}</legend>
+      <div class="form-date">
+        {{#errors.uk-date-of-departure}}
+        <span id="uk-date-of-departure-error" class="error-message">{{{errors.uk-date-of-departure.message}}}</span>
+        {{/errors.uk-date-of-departure}}
+        <p class="form-hint">{{#t}}fields.uk-date-of-departure.hint{{/t}}</p>
+        {{#input-date}}uk-date-of-departure{{/input-date}}
+      </div>
+    </fieldset>
+
+    {{#select}}uk-port-of-departure{{/select}}
+  </div>
+
+  <div id="travel-details-changed-no-div" class="panel-indent">
+    {{#radio-group}}uk-duration{{/radio-group}}
+  </div>
+
+  {{#input-submit}}continue{{/input-submit}}
+
+{{/form}}
+
+{{/partials-form}}
+
+{{/content}}
+
+{{/layout}}

--- a/apps/update-journey-details/views/uk-departure.html
+++ b/apps/update-journey-details/views/uk-departure.html
@@ -44,6 +44,8 @@
     {{#radio-group}}uk-duration{{/radio-group}}
   </div>
 
+  {{#radio-group}}uk-visit-more-than-once{{/radio-group}}
+
   {{#input-submit}}continue{{/input-submit}}
 
 {{/form}}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "connect-mongo": "^1.3.2",
     "connect-redis": "^3.0.2",
     "cookie-parser": "^1.3.5",
-    "evw-schemas": "^1.8.5",
+    "evw-schemas": "^2.0.0",
     "express": "^4.12.4",
     "express-partial-templates": "^0.1.0",
     "express-session": "^1.13.0",

--- a/test/apps/update-journey-details/controllers/check-your-answers.spec.js
+++ b/test/apps/update-journey-details/controllers/check-your-answers.spec.js
@@ -14,6 +14,8 @@ describe('apps/update-journey-details/controllers/check-your-answers', function(
         get: sinon.stub()
       }
     };
+    req.sessionModel.get.withArgs('know-departure-details').returns('No');
+    req.sessionModel.get.withArgs('uk-port-of-departure').returns('LGW');
     controller = new CheckYourAnswersController({
       template: 'check-your-answers'
     });
@@ -36,16 +38,16 @@ describe('apps/update-journey-details/controllers/check-your-answers', function(
       localsStub.should.have.been.calledOnce.calledWith(req, res);
     });
 
-    it('adds knowDepartureDetailsYes to locals', function() {
-      req.sessionModel.get.returns('Yes');
+    it('adds knowDepartureDetailsYes and ukPortOfDepartureDisplay to locals', function() {
+      req.sessionModel.get.withArgs('know-departure-details').returns('Yes');
       controller.locals(req, res).should.deep.equal({
         knowDepartureDetailsYes: true,
-        knowDepartureDetailsNo: false
+        knowDepartureDetailsNo: false,
+        ukPortOfDepartureDisplay: 'London - Gatwick'
       });
     });
 
     it('adds knowDepartureDetailsNo to locals', function() {
-      req.sessionModel.get.returns('No');
       controller.locals(req, res).should.deep.equal({
         knowDepartureDetailsYes: false,
         knowDepartureDetailsNo: true

--- a/test/apps/update-journey-details/controllers/check-your-answers.spec.js
+++ b/test/apps/update-journey-details/controllers/check-your-answers.spec.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const CheckYourAnswersController = require('../../../../apps/update-journey-details/controllers/check-your-answers');
+const EvwBaseController = require('../../../../apps/common/controllers/evw-base');
+
+describe('apps/update-journey-details/controllers/check-your-answers', function() {
+  let controller;
+  let req;
+  let res;
+
+  beforeEach(function() {
+    req = {
+      sessionModel: {
+        get: sinon.stub()
+      }
+    };
+    controller = new CheckYourAnswersController({
+      template: 'check-your-answers'
+    });
+  });
+
+  describe('#locals', function() {
+    let localsStub;
+
+    beforeEach(function() {
+      localsStub = sinon.stub(EvwBaseController.prototype, 'locals');
+      localsStub.returns({});
+    });
+
+    afterEach(function() {
+      localsStub.restore();
+    });
+
+    it('calls parent locals', function() {
+      controller.locals(req, res);
+      localsStub.should.have.been.calledOnce.calledWith(req, res);
+    });
+
+    it('adds knowDepartureDetailsYes to locals', function() {
+      req.sessionModel.get.returns('Yes');
+      controller.locals(req, res).should.deep.equal({
+        knowDepartureDetailsYes: true,
+        knowDepartureDetailsNo: false
+      });
+    });
+
+    it('adds knowDepartureDetailsNo to locals', function() {
+      req.sessionModel.get.returns('No');
+      controller.locals(req, res).should.deep.equal({
+        knowDepartureDetailsYes: false,
+        knowDepartureDetailsNo: true
+      });
+    });
+  });
+
+});

--- a/test/apps/update-journey-details/controllers/confirmation.spec.js
+++ b/test/apps/update-journey-details/controllers/confirmation.spec.js
@@ -58,7 +58,7 @@ describe('apps/update-journey-details/controllers/confirmation', function () {
         'knowDepartureDetails': 'Yes',
         'departureDate': '2017-01-30',
         'departureTravel': 'FL1001',
-        'portOfDeparture': 'LGW'
+        'portOfDeparture': 'London - Gatwick'
       });
     });
 

--- a/test/apps/update-journey-details/controllers/confirmation.spec.js
+++ b/test/apps/update-journey-details/controllers/confirmation.spec.js
@@ -10,8 +10,10 @@ describe('apps/update-journey-details/controllers/confirmation', function () {
   let mockRequest;
   let mockJsonSchema;
   let validateStub;
+  let model;
 
   beforeEach(function() {
+    model = Object.assign({}, modelFixture);
     mockRequest = {
       post: sinon.stub().yields(null, null, {
         membershipNumber: '123ABC',
@@ -37,7 +39,7 @@ describe('apps/update-journey-details/controllers/confirmation', function () {
 
   describe('#propMap', function () {
     it('returns mapped update ready for submission', function () {
-      ConfirmationController.propMap(modelFixture).should.deep.equal({
+      ConfirmationController.propMap(model).should.deep.equal({
         'membershipNumber' : 'ABC1234',
         'token' : 'token123',
         'arrivalTravel' : 'EK009',
@@ -51,7 +53,56 @@ describe('apps/update-journey-details/controllers/confirmation', function () {
         'portOfArrivalCode' : 'LGW',
         'inwardDepartureCountry': 'ARE',
         'inwardDeparturePort': 'Dubai',
-        'inwardDeparturePortCode': 'DXB'
+        'inwardDeparturePortCode': 'DXB',
+        'haveDepartureFromUkDetailsChanged': 'Yes',
+        'knowDepartureDetails': 'Yes',
+        'departureDate': '2017-01-30',
+        'departureTravel': 'FL1001',
+        'portOfDeparture': 'LGW'
+      });
+    });
+
+    it('returns mapped update when return journey is changed but is unknown', function() {
+      model['know-departure-details'] = 'No';
+      ConfirmationController.propMap(model).should.deep.equal({
+        'membershipNumber' : 'ABC1234',
+        'token' : 'token123',
+        'arrivalTravel' : 'EK009',
+        'arrivalDate' : '2016-10-10',
+        'arrivalTime' : '19:45',
+        'departureForUKDate' : '2016-10-10',
+        'departureForUKTime' : '01:01',
+        'flightDetailsCheck': 'Yes',
+        'dateCreated': moment().format('YYYY-MM-DD hh:mm:ss'),
+        'portOfArrival' : 'London - Gatwick',
+        'portOfArrivalCode' : 'LGW',
+        'inwardDepartureCountry': 'ARE',
+        'inwardDeparturePort': 'Dubai',
+        'inwardDeparturePortCode': 'DXB',
+        'haveDepartureFromUkDetailsChanged': 'Yes',
+        'knowDepartureDetails': 'No',
+        'ukDuration': '1 to 3 months'
+      });
+    });
+
+    it('returns mapped update when return journey not changed', function() {
+      model['travel-details-changed'] = 'No';
+      ConfirmationController.propMap(model).should.deep.equal({
+        'membershipNumber' : 'ABC1234',
+        'token' : 'token123',
+        'arrivalTravel' : 'EK009',
+        'arrivalDate' : '2016-10-10',
+        'arrivalTime' : '19:45',
+        'departureForUKDate' : '2016-10-10',
+        'departureForUKTime' : '01:01',
+        'flightDetailsCheck': 'Yes',
+        'dateCreated': moment().format('YYYY-MM-DD hh:mm:ss'),
+        'portOfArrival' : 'London - Gatwick',
+        'portOfArrivalCode' : 'LGW',
+        'inwardDepartureCountry': 'ARE',
+        'inwardDeparturePort': 'Dubai',
+        'inwardDeparturePortCode': 'DXB',
+        'haveDepartureFromUkDetailsChanged': 'No'
       });
     });
   });

--- a/test/fixtures/update-model.js
+++ b/test/fixtures/update-model.js
@@ -14,7 +14,7 @@ module.exports = {
       '/declaration'
   ],
   'flight-number': 'EK009',
-  'arrival-date': '10-10-2016',
+  'arrival-date': '2016-10-10',
   flightDetails: {
     flightNumber: 'EK009',
     inwardDepartureCountryPlane: 'United Arab Emirates',
@@ -39,6 +39,15 @@ module.exports = {
   'departure-date-year': '2016',
   'departure-time-hours': '1',
   'departure-time-minutes': '1',
-  'departure-date-formatted': '10 October 2016',
-  'accept-declaration': 'true'
-}
+  'departure-date-formatted': '10/10/2016',
+  'accept-declaration': 'true',
+  'travel-details-changed': 'Yes',
+  'know-departure-details': 'Yes',
+  'uk-date-of-departure': '2017-01-30',
+  'uk-date-of-departure-day': '30',
+  'uk-date-of-departure-month': '01',
+  'uk-date-of-departure-year': '2017',
+  'uk-duration': '1 to 3 months',
+  'uk-departure-travel-number': 'FL1001',
+  'uk-port-of-departure': 'LGW'
+};


### PR DESCRIPTION
Ask the user if their return travel details have changed and re-capture these details if necessary.

These questions have been added at the end of the form, just after asking for their flight departure details.
* Have your travel details for your departure from the UK changed?
* Do you have your travel details for your departure from the UK?
    * If yes, ask for travel number, departure date and port
    * If no, ask for duration
* Display the relevant answers on the check your answers page

Send these new details to Integration Service along with the rest of the update.

**New travel details changed question**
![travel details changed](https://cloud.githubusercontent.com/assets/1334068/22246528/38402b28-e22d-11e6-8280-fc3b30b2b6da.png)

**If user knows their travel details, they must fill them in here**
![know travel details yes](https://cloud.githubusercontent.com/assets/1334068/22246558/4ff59938-e22d-11e6-835d-b15e41fa13f1.png)

**If they don't know their travel details, they must select a duration**
![know travel details no](https://cloud.githubusercontent.com/assets/1334068/22246612/8332d3c4-e22d-11e6-9c2a-605e38feb632.png)

**Updated check your answers page**
![check your answers](https://cloud.githubusercontent.com/assets/1334068/22246624/8afdab42-e22d-11e6-8178-e6a52a9ffdad.png)

