### PR TITLE
Correct behaviour for editing flight number

### DIFF
--- a/apps/update-journey-details/controllers/flight-number.js
+++ b/apps/update-journey-details/controllers/flight-number.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const EvwBaseController = require('../../common/controllers/evw-base');
+
+module.exports = class FlightNumberController extends EvwBaseController {
+
+  process(req, res, callback) {
+    req.sessionModel.set('is-this-your-flight', null);
+    super.process(req, res, callback);
+  }
+
+};

--- a/apps/update-journey-details/steps.js
+++ b/apps/update-journey-details/steps.js
@@ -23,7 +23,7 @@ module.exports = {
   },
   '/flight-number': {
     template: 'flight-number',
-    controller: require('../common/controllers/evw-base'),
+    controller: require('./controllers/flight-number'),
     fields: [
       'flight-number'
     ],

--- a/apps/update-journey-details/views/check-your-answers.html
+++ b/apps/update-journey-details/views/check-your-answers.html
@@ -44,7 +44,7 @@
             <td class="data-departure-date bold">
                 {{values.flightDetails.departureDate}}
             </td>
-            <td><a href="flight-number#edit/flight-number" class="button">{{#t}}buttons.change{{/t}}</a></td>
+            <td><a href="departure-date#edit/departure-date" class="button">{{#t}}buttons.change{{/t}}</a></td>
         </tr>
         <tr>
             <td>{{#t}}pages.check-your-answers.table.departure-time{{/t}}</td>

--- a/test/apps/update-journey-details/controllers/flight-number.spec.js
+++ b/test/apps/update-journey-details/controllers/flight-number.spec.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const FlightNumberController = require('../../../../apps/update-journey-details/controllers/flight-number');
+const controller = new FlightNumberController({template: 'flight-number'});
+const EvwBaseController = require('../../../../apps/common/controllers/evw-base');
+
+describe('apps/update-journey-details/controllers/flight-number', function () {
+  let req;
+  let res;
+  let callback;
+
+  beforeEach(function() {
+    req = {
+      sessionModel: {
+        set: sinon.spy(),
+        attributes: {
+          'is-this-your-flight': 'Yes'
+        }
+      }
+    };
+    res = {};
+    callback = sinon.spy();
+  });
+
+  describe('process', function() {
+    let processStub;
+    beforeEach(function() {
+      processStub = sinon.stub(EvwBaseController.prototype, 'process');
+      processStub.yields();
+      controller.process(req, res, callback);
+    });
+
+    afterEach(function() {
+      processStub.restore();
+    });
+
+    it('resets the value', function() {
+      req.sessionModel.set.should.have.been.calledOnce.calledWith('is-this-your-flight', null);
+    });
+
+    it('calls parent process', function() {
+      processStub.should.have.been.calledOnce.calledWith(req, res, callback);
+    });
+
+    it('calls the callback', function() {
+      callback.should.have.been.calledOnce;
+    });
+
+  });
+});


### PR DESCRIPTION
Allow departure date to be edited separately to flight number

Setting `is-this-your-flight` to null when changing flight number.
* if a user tries to edit the flight number, but then go back on the browser to the check your answers page and try to submit the update, it will fail
* this is preferable to submitting an incorrect flight number