### PR TITLE
Bugfix/NIJ - prevent empty flight details submission

### DIFF
--- a/apps/update-journey-details/controllers/is-this-your-flight.js
+++ b/apps/update-journey-details/controllers/is-this-your-flight.js
@@ -1,8 +1,15 @@
 'use strict';
 
-const BaseController = require('hof').controllers.base;
+const EvwBaseController = require('../../common/controllers/evw-base');
 
-class IsThisYourFlightController extends BaseController {
+class IsThisYourFlightController extends EvwBaseController {
+  getValues(req, res, callback) {
+    if (!req.sessionModel.get('flightDetails')) {
+      return res.redirect('flight-number');
+    }
+    super.getValues(req, res, callback);
+  }
+
   locals(req, res) {
     return Object.assign({
       flightDetails: req.sessionModel.get('flightDetails')

--- a/apps/update-journey-details/controllers/is-this-your-flight.js
+++ b/apps/update-journey-details/controllers/is-this-your-flight.js
@@ -1,18 +1,13 @@
 'use strict';
 
-const util = require('util');
 const BaseController = require('hof').controllers.base;
 
-const IsThisYourFlightController = function IsThisYourFlightController() {
-  BaseController.apply(this, arguments);
-};
-
-util.inherits(IsThisYourFlightController, BaseController);
-
-IsThisYourFlightController.prototype.locals = function locals(req, res) {
-  return Object.assign({
-    flightDetails: req.sessionModel.get('flightDetails')
-  }, BaseController.prototype.locals.call(this, req, res));
-};
+class IsThisYourFlightController extends BaseController {
+  locals(req, res) {
+    return Object.assign({
+      flightDetails: req.sessionModel.get('flightDetails')
+    }, super.locals(req, res));
+  }
+}
 
 module.exports = IsThisYourFlightController;

--- a/test/apps/update-journey-details/controllers/is-this-your-flight.spec.js
+++ b/test/apps/update-journey-details/controllers/is-this-your-flight.spec.js
@@ -2,6 +2,8 @@
 
 const IsThisYourFlightController = require('../../../../apps/update-journey-details/controllers/is-this-your-flight');
 const controller = new IsThisYourFlightController({template: 'is-is-this-your-flight'});
+const EvwBaseController = require('../../../../apps/common/controllers/evw-base');
+
 const flightDetails = {
   flightNumber: 'KU101',
   inwardDepartureCountryPlane: 'United Arab Emirates',
@@ -18,20 +20,56 @@ const flightDetails = {
   arrivalTimePlaneHour: '19',
   arrivalTimePlaneMinutes: '45'
 };
-const req = {
-  sessionModel: {
-    get: function (key) {
-      return this.attributes[key];
-    },
-    attributes: {
-      flightDetails: flightDetails
-    }
-  },
-  params: {}
-};
 
 describe('apps/update-journey-details/controllers/is-this-your-flight', function () {
-  it('returns flight details', function () {
-    controller.locals(req).flightDetails.should.deep.equal(flightDetails);
+  let req;
+  let res;
+  let callback;
+
+  beforeEach(function() {
+    req = {
+      sessionModel: {
+        get: sinon.stub().returns(flightDetails),
+        attributes: {
+          flightDetails: flightDetails
+        }
+      },
+      params: {}
+    };
+    res = {
+      redirect: sinon.spy()
+    };
+    callback = sinon.spy();
   });
+
+  describe('#locals', function() {
+    it('returns flight details', function () {
+      controller.locals(req).flightDetails.should.deep.equal(flightDetails);
+    });
+  });
+
+  describe('#getValues', function() {
+    let getValuesStub;
+
+    beforeEach(function() {
+      getValuesStub = sinon.stub(EvwBaseController.prototype, 'getValues');
+      getValuesStub.yields();
+    });
+
+    afterEach(function() {
+      getValuesStub.restore();
+    });
+
+    it('redirects to flight-number if flight details are not set', function () {
+      req.sessionModel.get.returns(null);
+      controller.getValues(req, res, callback);
+      res.redirect.should.have.been.calledOnce.calledWith('flight-number');
+    });
+
+    it('continues as normal if flight details are present', function() {
+      controller.getValues(req, res, callback);
+      getValuesStub.should.have.been.calledOnce.calledWith(req, res, callback);
+    });
+  });
+
 });


### PR DESCRIPTION
If the users says 'No' this is not their flight and then clicks back in the browser, this will happen:

![screen shot 2017-02-07 at 16 36 11](https://cloud.githubusercontent.com/assets/1334068/22700753/8b9684f8-ed53-11e6-89ec-afebc85fbfda.png)

This fix sends the user back to the `flight-number` step if no flight details are found in the session.