### PR TITLE
Bugfix/EVW-2183 uk port of departure

### DIFF
--- a/apps/update-journey-details/controllers/check-your-answers.js
+++ b/apps/update-journey-details/controllers/check-your-answers.js
@@ -1,14 +1,13 @@
 'use strict';
 
 const EvwBaseController = require('../../common/controllers/evw-base');
-const getTypeaheadValue = require('../../../lib/typeahead-options').getTypeaheadValue;
-const allAirportsPortsStations = require('../../../lib/typeahead-options').all;
 
 module.exports = class CheckYourAnswersController extends EvwBaseController {
   locals(req, res) {
     let displayProps = {};
     if (req.sessionModel.get('know-departure-details') === 'Yes') {
-      const portToDisplay = getTypeaheadValue(req.sessionModel.get('uk-port-of-departure'), allAirportsPortsStations);
+      const getOptionValue = value => typeof value === 'string' ? value.substr(value.indexOf('_') + 1) : '';
+      const portToDisplay = getOptionValue(req.sessionModel.get('uk-port-of-departure'));
       displayProps.ukPortOfDepartureDisplay = portToDisplay;
     }
     return Object.assign({

--- a/apps/update-journey-details/controllers/confirmation.js
+++ b/apps/update-journey-details/controllers/confirmation.js
@@ -9,12 +9,11 @@ const logger = require('../../../lib/logger');
 const Validator = require('jsonschema').Validator;
 const v = new Validator();
 const schema = require('evw-schemas').evw.updateJourney.schema;
-const getTypeaheadValue = require('../../../lib/typeahead-options').getTypeaheadValue;
-const allAirportsPortsStations = require('../../../lib/typeahead-options').all;
 
 const propMap = (model) => {
   const f = model.flightDetails;
   const departureDateTime = moment.utc(`${f.departureDateRaw} ${f.departureTime}`);
+  const getOptionValue = value => typeof value === 'string' ? value.substr(value.indexOf('_') + 1) : '';
 
   const getReturnJourneyDetails = () => {
     let returnJourneyProps = {
@@ -34,7 +33,7 @@ const propMap = (model) => {
     if (model['know-departure-details'] === 'Yes') {
       Object.assign(returnJourneyProps, {
         departureTravel: model['uk-departure-travel-number'],
-        portOfDeparture: getTypeaheadValue(model['uk-port-of-departure'], allAirportsPortsStations),
+        portOfDeparture: getOptionValue(model['uk-port-of-departure']),
         departureDate: model['uk-date-of-departure']
       });
     }

--- a/data/ports.json
+++ b/data/ports.json
@@ -115,7 +115,7 @@
   { "code": "RMG", "countryCode": "GBR", "name": "RAMSGATE" ,"type":"boat" },
   { "code": "ROC", "countryCode": "GBR", "name": "Reading" ,"type":"boat" },
   { "code": "MOS", "countryCode": "GBR", "name": "Rhyl" ,"type":"boat" },
-  { "code": "MED ", "countryCode": "GBR", "name": "Ridham Dock" ,"type":"boat" },
+  { "code": "MED", "countryCode": "GBR", "name": "Ridham Dock" ,"type":"boat" },
   { "code": "MED", "countryCode": "GBR", "name": "Rochester" ,"type":"boat" },
   { "code": "LON", "countryCode": "GBR", "name": "Rochford" ,"type":"boat" },
   { "code": "COL", "countryCode": "GBR", "name": "Rowhedge" ,"type":"boat" },

--- a/lib/typeahead-options.js
+++ b/lib/typeahead-options.js
@@ -1,24 +1,15 @@
 'use strict';
 
-const _ = require('lodash');
 const allAirports = require('../data/airports.json');
 const allStations = require('../data/stations.json');
 const allPorts = require('../data/ports.json');
 const allCountries = require('../data/nationalities.json');
 
-function getTypeaheadValue(value, typeaheadData) {
-  if (!value || value === '') {
-    return null;
-  }
-  const result = _.find(typeaheadData, {'code': value});
-  return (result && result.name) ? result.name : value;
-}
-
 function mapListEntries(list) {
   return list.map(entry => {
     return {
       label: entry.name,
-      value: entry.code
+      value: entry.code ? entry.code + '_' + entry.name : entry.name
     };
   });
 }
@@ -81,7 +72,6 @@ module.exports = {
   nonBritishPorts: nonBritishPorts,
   britishStations: britishStations,
   nonBritishStations: nonBritishStations,
-  getTypeaheadValue: getTypeaheadValue,
   allAirports: allAirports,
   allStations: allStations,
   allPorts: allPorts,

--- a/test/apps/update-journey-details/controllers/check-your-answers.spec.js
+++ b/test/apps/update-journey-details/controllers/check-your-answers.spec.js
@@ -15,7 +15,7 @@ describe('apps/update-journey-details/controllers/check-your-answers', function(
       }
     };
     req.sessionModel.get.withArgs('know-departure-details').returns('No');
-    req.sessionModel.get.withArgs('uk-port-of-departure').returns('LGW');
+    req.sessionModel.get.withArgs('uk-port-of-departure').returns('LGW_London Gatwick Airport');
     controller = new CheckYourAnswersController({
       template: 'check-your-answers'
     });

--- a/test/fixtures/update-model.js
+++ b/test/fixtures/update-model.js
@@ -56,5 +56,5 @@ module.exports = {
   'uk-date-of-departure-year': '2017',
   'uk-duration': '1 to 3 months',
   'uk-departure-travel-number': 'FL1001',
-  'uk-port-of-departure': 'LGW'
+  'uk-port-of-departure': 'LGW_London Gatwick Airport'
 };

--- a/test/lib/typeahead-options.spec.js
+++ b/test/lib/typeahead-options.spec.js
@@ -28,8 +28,8 @@ describe('lib/typeahead-options', function() {
 
     it('returns British airports only', function() {
       const britishAirports = typeaheadOptions.britishAirports();
-      _.find(britishAirports, { value: 'LGW' }).value.should.equal('LGW');
-      should.equal(undefined, _.find(britishAirports, { value: 'LAX' }));
+      _.find(britishAirports, { value: 'LGW_London Gatwick Airport' }).value.should.equal('LGW_London Gatwick Airport');
+      should.equal(undefined, _.find(britishAirports, { value: 'LAX_Los Angeles International Airport' }));
     });
   });
 
@@ -56,8 +56,8 @@ describe('lib/typeahead-options', function() {
 
     it('returns non-British airports only', function() {
       const nonBritishAirports = typeaheadOptions.nonBritishAirports();
-      _.find(nonBritishAirports, { value: 'LAX' }).value.should.equal('LAX');
-      should.equal(undefined, _.find(nonBritishAirports, { value: 'LGW' }));
+      _.find(nonBritishAirports, { value: 'LAX_Los Angeles International Airport' }).value.should.equal('LAX_Los Angeles International Airport');
+      should.equal(undefined, _.find(nonBritishAirports, { value: 'LGW_London Gatwick Airport' }));
     });
   });
 
@@ -86,8 +86,8 @@ describe('lib/typeahead-options', function() {
 
     it('returns British airports only', function() {
       const britishStations = typeaheadOptions.britishStations();
-      _.find(britishStations, { value: 'STP' }).value.should.equal('STP');
-      should.equal(undefined, _.find(britishStations, { value: 'COQ' }));
+      _.find(britishStations, { value: 'STP_London (St Pancras Intl)' }).value.should.equal('STP_London (St Pancras Intl)');
+      should.equal(undefined, _.find(britishStations, { value: 'COQ_Calais (Coquelles)' }));
     });
   });
 
@@ -116,8 +116,8 @@ describe('lib/typeahead-options', function() {
 
     it('returns non-British stations only', function() {
       const nonBritishStations = typeaheadOptions.nonBritishStations();
-      _.find(nonBritishStations, { value: 'COQ' }).value.should.equal('COQ');
-      should.equal(undefined, _.find(nonBritishStations, { value: 'STP' }));
+      _.find(nonBritishStations, { value: 'COQ_Calais (Coquelles)' }).value.should.equal('COQ_Calais (Coquelles)');
+      should.equal(undefined, _.find(nonBritishStations, { value: 'STP_London (St Pancras Intl)' }));
     });
   });
 
@@ -171,8 +171,8 @@ describe('lib/typeahead-options', function() {
 
     it('returns British ports only', function() {
       const britishPorts = typeaheadOptions.britishPorts();
-      _.find(britishPorts, { value: 'DOV' }).value.should.equal('DOV');
-      should.equal(undefined, _.find(britishPorts, { value: 'JCT' }));
+      _.find(britishPorts, { value: 'DOV_DOVER' }).value.should.equal('DOV_DOVER');
+      should.equal(undefined, _.find(britishPorts, { value: 'JCT_Calais Passenger' }));
     });
   });
 
@@ -202,8 +202,8 @@ describe('lib/typeahead-options', function() {
 
     it('returns non-British ports only', function() {
       const nonBritishPorts = typeaheadOptions.nonBritishPorts();
-      _.find(nonBritishPorts, { value: 'JCT' }).value.should.equal('JCT');
-      should.equal(undefined, _.find(nonBritishPorts, { value: 'DOV' }));
+      _.find(nonBritishPorts, { value: 'JCT_Calais Passenger' }).value.should.equal('JCT_Calais Passenger');
+      should.equal(undefined, _.find(nonBritishPorts, { value: 'DOV_DOVER' }));
     });
   });
 
@@ -233,26 +233,6 @@ describe('lib/typeahead-options', function() {
     it('returns an array of all stations', function() {
       typeaheadOptions.allCountries.should.be.an.array;
       typeaheadOptions.allCountries.should.be.lengthOf(212);
-    });
-  });
-
-  describe('#getTypeaheadValue', function() {
-    it('returns null if value is null', function() {
-      const value = typeaheadOptions.getTypeaheadValue(null, typeaheadOptions.allCountries);
-      should.equal(value, null);
-    });
-
-    it('returns null if value is empty', function() {
-      const value = typeaheadOptions.getTypeaheadValue('', typeaheadOptions.allCountries);
-      should.equal(value, null);
-    });
-
-    it('returns value from typeahead data if it exists', function() {
-      typeaheadOptions.getTypeaheadValue('USA', typeaheadOptions.allCountries).should.equal('United States of America');
-    });
-
-    it('returns value passed in if it does not exist in the typeahead', function() {
-      typeaheadOptions.getTypeaheadValue('Totally made up country', typeaheadOptions.allCountries).should.equal('Totally made up country');
     });
   });
 


### PR DESCRIPTION
The same as https://github.com/UKHomeOffice/evw-customer-hof/pull/262 for self-serve

> This PR seeks to prevent confusion between typeahead values which have the same code or no code at all. The UK port of departure scenario is just one which could occur.
> 
> To solve this I have done the following:
> 
> * use either CODE_Value (e.g. LGW_London Gatwick Airport) or Value (e.g. Derby) as the option value, meaning each option should be unique
> * this value is then saved into the session for that field
> * when displaying the check your answer page we pull the display value from the field by getting the part beyond the underscore
