### PR TITLE
EVW-2191 Fixing travel within 3 months failing validation

### DIFF
--- a/apps/common/controllers/evw-base.js
+++ b/apps/common/controllers/evw-base.js
@@ -38,7 +38,7 @@ module.exports = class EvwBaseController extends BaseController {
       let value = req.form.values[key];
       req.fields[key].validators.forEach((validator) => {
         validator.formValues = Object.assign({}, req.sessionModel.attributes, req.form.values);
-        if (validator.type(value, validator.arguments)) {
+        if (validator.type(value, typeof validator.arguments === 'function' ? validator.arguments() : validator.arguments)) {
           error = new ErrorController(key, {
             type: validator.type.name
           });

--- a/apps/update-journey-details/fields/departure-date.js
+++ b/apps/update-journey-details/fields/departure-date.js
@@ -9,10 +9,10 @@ module.exports = {
     validate: ['required', 'date'],
     validators: [{
       type: beforeDate,
-      arguments: moment().add(48, 'hours').format('YYYY-MM-DD')
+      arguments: () => moment().add(48, 'hours').format('YYYY-MM-DD')
     }, {
       type: afterDate,
-      arguments: moment().add(3, 'months').format('YYYY-MM-DD')
+      arguments: () => moment().add(3, 'months').format('YYYY-MM-DD')
     }]
   },
   'departure-date-day': {

--- a/apps/update-journey-details/fields/uk-departure.js
+++ b/apps/update-journey-details/fields/uk-departure.js
@@ -60,10 +60,10 @@ module.exports = {
     validate: ['required', 'date'],
     validators: [{
       type: beforeDate,
-      arguments: moment().add(48, 'hours').format('YYYY-MM-DD')
+      arguments: () => moment().add(48, 'hours').format('YYYY-MM-DD')
     }, {
       type: afterDate,
-      arguments: moment().add(6, 'months').format('YYYY-MM-DD')
+      arguments: () => moment().add(6, 'months').format('YYYY-MM-DD')
     }],
     dependent: {
       field: 'know-departure-details',

--- a/test/apps/common/controllers/evw-base.spec.js
+++ b/test/apps/common/controllers/evw-base.spec.js
@@ -113,6 +113,8 @@ describe('apps/common/controllers/evw-base', function() {
     let key = 'lifetime-expiry';
     let validatorTypeStub = sinon.stub();
     let secondValidator = sinon.stub();
+    let validatorWithFunction = sinon.stub();
+    let stubValidatorFunction = sinon.stub().returns(2);
     let seshStub = sinon.stub();
     let req = {
       sessionModel: seshStub,
@@ -123,6 +125,9 @@ describe('apps/common/controllers/evw-base', function() {
             arguments: 100
           }, {
             type: secondValidator
+          }, {
+            type: validatorWithFunction,
+            arguments: stubValidatorFunction
           }]
         }
       },
@@ -134,6 +139,7 @@ describe('apps/common/controllers/evw-base', function() {
     };
 
     beforeEach(function() {
+      stubValidatorFunction.reset();
       BaseController.prototype.validateField = sinon.stub();
     });
 
@@ -150,6 +156,12 @@ describe('apps/common/controllers/evw-base', function() {
       it('calls custom validator', function () {
         controller.validateField(key, req);
         validatorTypeStub.should.have.been.calledWith(88, 100);
+      });
+
+      it('calls custom validator with function', function() {
+        controller.validateField(key, req);
+        stubValidatorFunction.should.have.been.calledOnce;
+        validatorWithFunction.should.have.been.calledWith(88, 2);
       });
 
       describe('☑️ valid field ☑️', function () {


### PR DESCRIPTION
The issue was caused by the arguments given to custom validators only being run at startup, not whenever the validators are used.

This is fixed by doing the following:

* check if argument for custom validator is a function, in `evw-base.js` `validateField` function
* if it's a function, run it and pass the result to the validator function
* otherwise, just pass the value to the validator function
* fixing all uses of the `beforeDate` and `afterDate` custom validators