### PR TITLE
[NIJ] remove cookie check from token

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,0 @@
-#read-only
-registry=https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual
-_auth = cmVhZC1vbmx5OkFQMmVSbkR1Q2dQTmNzWDZZUDk3ejloaHhXVlNyVlZzS2NzcTJ5
-always-auth = true
-email = jon.shanks+artifactoryro@gmail.com
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ services:
 cache:
   directories:
   - node_modules
-before_install:
-  - printf "registry=https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual\n_auth=${NPM_TOKEN}\nalways-auth=true\nemail=${NPM_EMAIL}\n" >> .npmrc
 before_script:
 - npm run sass
 - NODE_ENV='ci' npm start &

--- a/acceptance_tests/features/update-journey-details.feature
+++ b/acceptance_tests/features/update-journey-details.feature
@@ -27,10 +27,10 @@ Scenario: Entering new flight details and correct flight found
   And the "Flight number" should contain "KU101"
   And the "Departure airport" should contain "Dubai"
   And the "Departure date" should contain a date "2 months" in the future
-  And the "Departure time" should contain "14:55"
+  And the "Departure time" should contain "14:35"
   And the "Arrival airport" should contain "London Gatwick Airport"
   And the "Arrival date" should contain a date "2 months" in the future
-  And the "Arrival time" should contain "19:45"
+  And the "Arrival time" should contain "18:25"
   And I click "Yes"
   And I continue
   # Return travel
@@ -55,7 +55,7 @@ Scenario: Entering new flight details and correct flight found
     Departure date
                       ${"2 months" in the "future"}
     Departure time
-                      14:55
+                      14:35
     Flight number
                       KU101
     Arrival airport
@@ -63,7 +63,7 @@ Scenario: Entering new flight details and correct flight found
     Arrival date
                       ${"2 months" in the "future"}
     Arrival time
-                      19:45
+                      18:25
     Length of stay
                       1 to 3 months
     """

--- a/apps/update-journey-details/controllers/how-will-you-arrive.js
+++ b/apps/update-journey-details/controllers/how-will-you-arrive.js
@@ -28,7 +28,7 @@ const checkValidated = (req, res, callback) => {
 
 const validateApp = (req, res, callback) => {
   let evwNumber = req.query.evwNumber;
-  let token = req.query.token;
+  let token = req.query.token.replace('?hof-cookie-check', '');
 
   if(!evwNumber || !token) {
     return fourOhfourIt(res);

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "connect-redis": "^3.0.2",
     "cookie-parser": "^1.3.5",
     "evw-ffs": "^1.0.0",
-    "evw-schemas": "^4.0.0",
+    "evw-schemas": "^5.0.0",
     "express": "^4.12.4",
     "express-partial-templates": "^0.1.0",
     "express-session": "^1.13.0",


### PR DESCRIPTION
Strip `?hof-cookie-check` from token URL param
* this is causing an issue due to breaking schema validation at the end of the update application
* the token was too long, because it was appended with `?hof-cookie-check`

Also fixing acceptance tests for new flight schedule and making this work on travis with the open source `evw-schemas`