### PR TITLE
Readme - fix - url for update-journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm run dev:mock
 
 Go to http://localhost:8080/find-your-application
 
-When you’re asked to check your e-mail, go to http://localhost:8080/update-journey-details/how-will-you-arrive?evwNumber=VALID
+When you’re asked to check your e-mail, go to http://localhost:8080/update-journey-details/how-will-you-arrive?evwNumber=valid&token=token
 
 ## Running the tests
 You will need the server running to run the cucumber tests against.


### PR DESCRIPTION
Requires full url the first time you go to the page and saves it to your cookies so next time you don't need to go to the full path

http://localhost:8080/update-journey-details/how-will-you-arrive?evwNumber=valid&token=token