### PR TITLE
WIP: DPS-1672: prevent session issues

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,6 +17,7 @@ module.exports = {
   govukAssetPath: process.env.GOVUK_ASSET_PATH || '/govuk-assets',
   appPath: 'find-your-application/enter-your-details',
   session: {
+    name: 'evwselfserve.sid',
     secret: process.env.SESSION_SECRET || 'howdoesyourgardengrow',
     ttl: process.env.SESSION_TTL || 1200 /* 20 mins */
   },

--- a/lib/session/mongo.js
+++ b/lib/session/mongo.js
@@ -15,6 +15,7 @@ module.exports = (config) => {
     },
     store: new MongoStore({
       url: config.mongo.connectionString,
+      ttl: config.session.ttl
     })
   });
 };

--- a/lib/session/mongo.js
+++ b/lib/session/mongo.js
@@ -3,6 +3,7 @@ const MongoStore = require('connect-mongo')(session);
 
 module.exports = (config) => {
   return session({
+    name: config.session.name,
     secret: config.session.secret,
     ttl: config.session.ttl,
     resave: true,

--- a/test/lib/session/mongo.spec.js
+++ b/test/lib/session/mongo.spec.js
@@ -3,6 +3,7 @@
 const proxyquire = require('proxyquire').noPreserveCache();
 const mockConfig = {
   session: {
+    name: 'sessionName',
     secret: 'ohsosecret',
     ttl: 5000
   },
@@ -36,6 +37,7 @@ describe('session/mongo', function() {
 
   it('session is called with config options', function() {
     sessionStub.should.have.been.calledWith({
+      name: 'sessionName',
       secret: 'ohsosecret',
       ttl: 5000,
       cookie: {

--- a/test/lib/session/mongo.spec.js
+++ b/test/lib/session/mongo.spec.js
@@ -9,7 +9,8 @@ const mockConfig = {
   mongo: {
     port: 27017,
     host: 'localhost',
-    connectionString: 'mongodb://notarealdatabase:27016'
+    connectionString: 'mongodb://notarealdatabase:27016',
+    ttl: 5000
   }
 };
 
@@ -28,7 +29,8 @@ describe('session/mongo', function() {
 
   it('creates a session with a mongo store', function() {
     mongoStoreStub.should.have.been.calledWith({
-      url: mockConfig.mongo.connectionString
+      url: mockConfig.mongo.connectionString,
+      ttl: 5000
     });
   });
 


### PR DESCRIPTION
https://jira.digital.homeoffice.gov.uk/browse/DPS-1672

Our recent weird session issues on UAT with EVW Self Serve were triggered by me putting the incorrect path on an image.

Instead of using `{{assetPath}}/images` to point to EVW Self Serve’s image folder, I pointed the image to `/public/images`, which is EVW Customer’s image location.

EVW Customer happily served up this image, and set a `connect.sid` session cookie at the same time. This overwrote EVW Self Serve’s `connect.sid` session cookie (because both apps are hosted on the same domain), meaning EVW Self Serve lost its session.

The image [has been pointed to the right place](https://github.com/UKHomeOffice/evw-self-serve/commit/761d4cd26096b60503ee1f1fa5b815eba831b350), but it unsurprisingly took a long time for us to work out that this was the cause of the problem.

This pull request gives the EVW Self Serve cookie a unique name, so that EVW Customer can’t accidentally overwrite EVW Self Serve sessions, and thus should avoid similar difficult-to-debug problems in future. It also passes the session time-to-live setting to the Mongo store, so that session expiry time is set correctly to 20 minutes.

It might be worth looking at how we serve assets like images, as we probably don‘t need to send session cookies along with those requests.